### PR TITLE
Add CombinedCertificateValidationContext.

### DIFF
--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -238,12 +238,27 @@ message CommonTlsContext {
   // Configs for fetching TLS certificates via SDS API.
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6;
 
+  message CombinedCertificateValidationContext {
+    // How to validate peer certificates.
+    CertificateValidationContext default_validation_context = 1;
+
+    // Config for fetching validation context via SDS API.
+    SdsSecretConfig validation_context_sds_secret_config = 2;
+  };
+
   oneof validation_context_type {
     // How to validate peer certificates.
     CertificateValidationContext validation_context = 3;
 
     // Config for fetching validation context via SDS API.
     SdsSecretConfig validation_context_sds_secret_config = 7;
+
+    // Default certificate validation context holds default value for any field
+    // in CertificateValidationContext. If SDS server returns CertificateValidationContext
+    // that contains an empty field, e.g. verify_subject_alt_name, Envoy checks
+    // default_validation_context.verify_subject_alt_name, and uses this default
+    // value for validation.
+    CombinedCertificateValidationContext combined_validation_context = 8;
   }
 
   // Supplies the list of ALPN protocols that the listener should expose. In

--- a/include/envoy/secret/BUILD
+++ b/include/envoy/secret/BUILD
@@ -21,6 +21,7 @@ envoy_cc_library(
         "//include/envoy/common:callback",
         "//include/envoy/ssl:certificate_validation_context_config_interface",
         "//include/envoy/ssl:tls_certificate_config_interface",
+        "@envoy_api//envoy/api/v2/auth:cert_cc",
     ],
 )
 

--- a/include/envoy/secret/secret_provider.h
+++ b/include/envoy/secret/secret_provider.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 
+#include "envoy/api/v2/auth/cert.pb.h"
 #include "envoy/common/callback.h"
 #include "envoy/common/pure.h"
 #include "envoy/ssl/certificate_validation_context_config.h"
@@ -21,6 +22,10 @@ public:
    * @return the secret. Returns nullptr if the secret is not ready.
    */
   virtual const SecretType* secret() const PURE;
+
+  // Sets a default secret. Once the default secret is set, it will be merged with dynamic secret
+  // as new secret to provide.
+  virtual void setDefaultSecret(const envoy::api::v2::auth::Secret&) PURE;
 
   /**
    * Add secret update callback into secret provider.

--- a/source/common/secret/secret_manager_impl.cc
+++ b/source/common/secret/secret_manager_impl.cc
@@ -34,6 +34,9 @@ void SecretManagerImpl::addStaticSecret(const envoy::api::v2::auth::Secret& secr
     }
     break;
   }
+  // Static secret of type
+  // envoy::api::v2::auth::CommonTlsContext::ValidationContextTypeCase::kCombinedValidationContext
+  // is not useful.
   default:
     throw EnvoyException("Secret type not implemented");
   }


### PR DESCRIPTION
Signed-off-by: JimmyCYJ <jimmychen.0102@gmail.com>

*Description*: Implement a new validation context type CombinedCertificateValidationContext, which has a default CertificateValidationContextoption and SDS config. This default CertificateValidationContext will be merged with dynamic CertificateValidationContext into a new secret to serve. This is option 4 in https://docs.google.com/document/d/12gdjGN5m3v4vxUnDAglCP6pyyMoeuVGAGo7D_jc27jw/edit?usp=sharing
*Risk Level*: Low
