### PR TITLE
Make timer work for wasm module

### DIFF
--- a/api/wasm/cpp/proxy_wasm_intrinsics.cc
+++ b/api/wasm/cpp/proxy_wasm_intrinsics.cc
@@ -27,6 +27,8 @@ extern "C" EMSCRIPTEN_KEEPALIVE void proxy_onCreate(uint32_t context_id) {
   ensureContext(context_id)->onCreate();
 }
 
+extern "C" EMSCRIPTEN_KEEPALIVE void proxy_onTick() { ensureContext(0)->onTick(); }
+
 extern "C" EMSCRIPTEN_KEEPALIVE FilterHeadersStatus proxy_onRequestHeaders(uint32_t context_id) {
   auto c = getContext(context_id);
   if (!c)

--- a/api/wasm/cpp/proxy_wasm_intrinsics.h
+++ b/api/wasm/cpp/proxy_wasm_intrinsics.h
@@ -227,6 +227,7 @@ public:
   virtual void onDone() {}
   virtual void onLog() {}
   virtual void onDelete() {}
+  virtual void onTick() {}
 
   virtual void onHttpCallResponse(uint32_t token, std::unique_ptr<WasmData> header_pairs,
                                   std::unique_ptr<WasmData> body,

--- a/api/wasm/cpp/proxy_wasm_intrinsics.js
+++ b/api/wasm/cpp/proxy_wasm_intrinsics.js
@@ -1,5 +1,6 @@
 mergeInto(LibraryManager.library, {
     proxy_log: function () {},
+    proxy_setTickPeriodMilliseconds: function () {},
     proxy_getRequestMetadata: function () {},
     proxy_setRequestMetadata: function () {},
     proxy_getRequestMetadataPairs: function () {},

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -277,7 +277,7 @@ class Wasm : public Envoy::Server::Wasm,
 public:
   Wasm(absl::string_view vm, absl::string_view id, absl::string_view initial_configuration,
        Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher);
-  Wasm(const Wasm& other);
+  Wasm(const Wasm& other, Event::Dispatcher& dispatcher);
   ~Wasm() {}
 
   bool initialize(const std::string& code, absl::string_view name, bool allow_precompiled);
@@ -355,7 +355,6 @@ private:
   uint32_t next_context_id_ = 0;
   std::unique_ptr<WasmVm> wasm_vm_;
   std::shared_ptr<Context> general_context_; // Context unrelated to any specific stream.
-  std::function<void(Common::Wasm::Context*)> tick_;
   std::chrono::milliseconds tick_period_;
   Event::TimerPtr timer_;
 


### PR DESCRIPTION
This includes several changes to make timer work for wasm module:

* instead of copying dispatcher from base wasm, copy the dispatcher from filter construction function. dispatcher from base wasm cannot be used in thread local context due to thread safe check in envoy.
* remove `tick_` function pointer, seems to be usefulness. 
* add ontick and set period into wasm intrinsic api.