### PR TITLE
bazel: replace PACKAGE_NAME by native.package_name()

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -190,7 +190,7 @@ def envoy_cc_library(
             envoy_external_dep_path("spdlog"),
             envoy_external_dep_path("fmtlib"),
         ],
-        include_prefix = envoy_include_prefix(PACKAGE_NAME),
+        include_prefix = envoy_include_prefix(native.package_name()),
         alwayslink = 1,
         linkstatic = 1,
         linkstamp = select({
@@ -246,7 +246,7 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
         copts = envoy_copts("@envoy", test = True),
         linkopts = envoy_test_linkopts(),
         linkstatic = 1,
-        args = [PACKAGE_NAME + "/" + corpus],
+        args = [native.package_name() + "/" + corpus],
         # No fuzzing on OS X.
         deps = select({
             "@bazel_tools//tools/osx:darwin": ["//test:dummy_main"],
@@ -451,7 +451,7 @@ def envoy_proto_library(
 # This is used for testing only.
 def envoy_proto_descriptor(name, out, srcs = [], external_deps = []):
     input_files = ["$(location " + src + ")" for src in srcs]
-    include_paths = [".", PACKAGE_NAME]
+    include_paths = [".", native.package_name()]
 
     if "api_httpbody_protos" in external_deps:
         srcs.append("@googleapis//:api_httpbody_protos_src")

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -71,7 +71,7 @@ envoy_cc_library(
 envoy_basic_cc_library(
     name = "fmt_lib",
     hdrs = ["fmt.h"],
-    include_prefix = envoy_include_prefix(PACKAGE_NAME),
+    include_prefix = envoy_include_prefix(native.package_name()),
 )
 
 envoy_cc_library(


### PR DESCRIPTION
PACKAGE_NAME is deprecated. 
See
https://docs.bazel.build/versions/master/skylark/lib/native.html#package_name

This is required by bazel version above 0.16, otherwise istio/proxy would fail to build.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

*Description*:
We might need this in dev env unless you use an ancient bazel version. 

*Risk Level*:
Low
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
