### PR TITLE
Add clock into intrinsic api into wasm runtime

### DIFF
--- a/api/wasm/cpp/proxy_wasm_intrinsics.h
+++ b/api/wasm/cpp/proxy_wasm_intrinsics.h
@@ -52,6 +52,8 @@ extern "C" void proxy_log(LogLevel level, const char* logMessage, size_t message
 
 extern "C" void proxy_setTickPeriodMilliseconds(uint32_t millisecond);
 
+extern "C" uint64_t proxy_getCurrentTimeNanoseconds();
+
 //
 // Low Level API.
 //

--- a/api/wasm/cpp/proxy_wasm_intrinsics.js
+++ b/api/wasm/cpp/proxy_wasm_intrinsics.js
@@ -1,6 +1,7 @@
 mergeInto(LibraryManager.library, {
     proxy_log: function () {},
     proxy_setTickPeriodMilliseconds: function () {},
+    proxy_getCurrentTimeNanoseconds: function() {},
     proxy_getProtocol: function () {},
     proxy_getMetadata: function () {},
     proxy_setMetadata: function () {},

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -516,6 +516,10 @@ void setTickPeriodMillisecondsHandler(void* raw_context, uint32_t tick_period_mi
   WASM_CONTEXT(raw_context)->setTickPeriod(std::chrono::milliseconds(tick_period_milliseconds));
 }
 
+uint64_t getCurrentTimeNanosecondsHandler(void* raw_context) {
+  return WASM_CONTEXT(raw_context)->getCurrentTimeNanoseconds();
+}
+
 void logHandler(void* raw_context, uint32_t level, uint32_t address, uint32_t size) {
   auto context = WASM_CONTEXT(raw_context);
   context->scriptLog(static_cast<spdlog::level::level_enum>(level),
@@ -615,6 +619,11 @@ const uint8_t* decodeVarint(const uint8_t* pos, const uint8_t* end, uint32_t* ou
 
 void Context::setTickPeriod(std::chrono::milliseconds tick_period) {
   wasm_->setTickPeriod(tick_period);
+}
+
+uint64_t Context::getCurrentTimeNanoseconds() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+    wasm_->time_source_.systemTime().time_since_epoch()).count();
 }
 
 // Shared Data
@@ -1157,7 +1166,8 @@ Wasm::Wasm(absl::string_view vm, absl::string_view id, absl::string_view initial
            Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher,
            Stats::Scope& scope, Stats::ScopeSharedPtr owned_scope)
     : cluster_manager_(cluster_manager), dispatcher_(dispatcher), scope_(scope),
-      owned_scope_(owned_scope), initial_configuration_(initial_configuration) {
+      owned_scope_(owned_scope), time_source_(dispatcher.timeSystem()),
+      initial_configuration_(initial_configuration) {
   wasm_vm_ = Common::Wasm::createWasmVm(vm);
   id_ = std::string(id);
 }
@@ -1231,6 +1241,7 @@ void Wasm::registerCallbacks() {
   _REGISTER_PROXY(httpCall);
 
   _REGISTER_PROXY(setTickPeriodMilliseconds);
+  _REGISTER_PROXY(getCurrentTimeNanoseconds);
 
   _REGISTER_PROXY(defineMetric);
   _REGISTER_PROXY(incrementMetric);
@@ -1281,7 +1292,8 @@ void Wasm::getFunctions() {
 
 Wasm::Wasm(const Wasm& wasm, Event::Dispatcher& dispatcher)
     : std::enable_shared_from_this<Wasm>(wasm), cluster_manager_(wasm.cluster_manager_),
-      dispatcher_(dispatcher), scope_(wasm.scope_), owned_scope_(wasm.owned_scope_) {
+      dispatcher_(dispatcher), scope_(wasm.scope_), owned_scope_(wasm.owned_scope_),
+      time_source_(dispatcher.timeSystem()) {
   wasm_vm_ = wasm.wasmVm()->clone();
   general_context_ = createContext();
   getFunctions();

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -555,15 +555,15 @@ public:
                                 WasmCallback5Int f) PURE;
   virtual void registerCallback(absl::string_view moduleName, absl::string_view functionName,
                                 WasmCallback9Int f) PURE;
-  virtual void registerCallback(absl::string_view moduleName, absl::string_view functionName,
-                                WasmCallback_mj f) PURE;
 
   virtual void registerCallback(absl::string_view moduleName, absl::string_view functionName,
                                 WasmCallback_Zjl f) PURE;
   virtual void registerCallback(absl::string_view moduleName, absl::string_view functionName,
                                 WasmCallback_Zjm f) PURE;
   virtual void registerCallback(absl::string_view moduleName, absl::string_view functionName,
-                                WasmCallback_mjj f) PURE;
+                                WasmCallback_mjj f) PURE;  
+  virtual void registerCallback(absl::string_view moduleName, absl::string_view functionName,
+                                WasmCallback_mj f) PURE;
 
   // Register typed value exported by the host environment.
   virtual std::unique_ptr<Global<double>>

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -68,6 +68,7 @@ using WasmCallback9Int = uint32_t (*)(void*, uint32_t, uint32_t, uint32_t, uint3
 using WasmCallback_Zjl = void (*)(void*, uint32_t, int64_t);
 using WasmCallback_Zjm = void (*)(void*, uint32_t, uint64_t);
 using WasmCallback_mjj = uint64_t (*)(void*, uint32_t);
+using WasmCallback_mj = uint64_t (*)(void*);
 
 // Sadly we don't have enum class inheritance in c++-14.
 enum class StreamType : int { Request = 0, Response = 1, MAX = 1 };
@@ -136,7 +137,8 @@ public:
   //
   virtual void scriptLog(spdlog::level::level_enum level, absl::string_view message);
   virtual void setTickPeriod(std::chrono::milliseconds tick_period);
-
+  virtual uint64_t getCurrentTimeNanoseconds();
+  
   //
   // AccessLog::Instance
   //
@@ -430,6 +432,7 @@ private:
   Event::TimerPtr timer_;
   Stats::ScopeSharedPtr
       owned_scope_; // When scope_ is not owned by a higher level (e.g. for WASM services).
+  TimeSource& time_source_;
 
   // Calls into the VM.
   WasmCall0Void onStart_;
@@ -552,6 +555,8 @@ public:
                                 WasmCallback5Int f) PURE;
   virtual void registerCallback(absl::string_view moduleName, absl::string_view functionName,
                                 WasmCallback9Int f) PURE;
+  virtual void registerCallback(absl::string_view moduleName, absl::string_view functionName,
+                                WasmCallback_mj f) PURE;
 
   virtual void registerCallback(absl::string_view moduleName, absl::string_view functionName,
                                 WasmCallback_Zjl f) PURE;

--- a/source/extensions/common/wasm/wavm/wavm.cc
+++ b/source/extensions/common/wasm/wavm/wavm.cc
@@ -264,6 +264,7 @@ struct Wavm : public WasmVm {
   _REGISTER_CALLBACK(WasmCallback_Zjl);
   _REGISTER_CALLBACK(WasmCallback_Zjm);
   _REGISTER_CALLBACK(WasmCallback_mjj);
+  _REGISTER_CALLBACK(WasmCallback_mj);
 #undef _REGISTER_CALLBACK
 
   std::unique_ptr<Global<double>> makeGlobal(absl::string_view moduleName, absl::string_view name,


### PR DESCRIPTION
Add a new API method `getCurrentTimeNanoseconds` utilizing enovy's time source.
