### PR TITLE
Fix connection reuse by delaying a poll cycle.

### DIFF
--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -30,6 +30,10 @@ ConnPoolImpl::ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSha
       upstream_ready_timer_(dispatcher_.createTimer([this]() { onUpstreamReady(); })) {}
 
 ConnPoolImpl::~ConnPoolImpl() {
+  while (!delayed_clients_.empty()) {
+    delayed_clients_.front()->codec_client_->close();
+  }
+
   while (!ready_clients_.empty()) {
     ready_clients_.front()->codec_client_->close();
   }
@@ -147,7 +151,12 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, Network::ConnectionEv
     } else if (!client.connect_timer_) {
       // The connect timer is destroyed on connect. The lack of a connect timer means that this
       // client is idle and in the ready pool.
-      removed = client.removeFromList(ready_clients_);
+      if (client.delayed_) {
+        client.delayed_ = false;
+        removed = client.removeFromList(delayed_clients_);
+      } else {
+        removed = client.removeFromList(ready_clients_);
+      }
       check_for_drained = false;
     } else {
       // The only time this happens is if we actually saw a connect failure.
@@ -220,6 +229,11 @@ void ConnPoolImpl::onResponseComplete(ActiveClient& client) {
 
 void ConnPoolImpl::onUpstreamReady() {
   upstream_ready_enabled_ = false;
+  while (!delayed_clients_.empty()) {
+    ActiveClient& client = *delayed_clients_.front();
+    client.delayed_ = false;
+    client.moveBetweenLists(delayed_clients_, ready_clients_);
+  }
   while (!pending_requests_.empty() && !ready_clients_.empty()) {
     ActiveClient& client = *ready_clients_.front();
     ENVOY_CONN_LOG(debug, "attaching to next request", *client.codec_client_);
@@ -234,7 +248,11 @@ void ConnPoolImpl::onUpstreamReady() {
 
 void ConnPoolImpl::processIdleClient(ActiveClient& client, bool delay) {
   client.stream_wrapper_.reset();
-  if (pending_requests_.empty() || delay) {
+  if (delay) {
+    ENVOY_CONN_LOG(debug, "moving to delay", *client.codec_client_);
+    client.delayed_ = true;
+    client.moveBetweenLists(busy_clients_, delayed_clients_);
+  } else if (pending_requests_.empty()) {
     // There is nothing to service or delayed processing is requested, so just move the connection
     // into the ready list.
     ENVOY_CONN_LOG(debug, "moving to ready", *client.codec_client_);

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -239,6 +239,10 @@ void ConnPoolImpl::onUpstreamReady() {
       client.moveBetweenLists(delayed_clients_, ready_clients_);
     }
   }
+  if (!delayed_clients_.empty()) {
+    upstream_ready_enabled_ = true;
+    upstream_ready_timer_->enableTimer(std::chrono::milliseconds(0));
+  }
   while (!pending_requests_.empty() && !ready_clients_.empty()) {
     ActiveClient& client = *ready_clients_.front();
     ENVOY_CONN_LOG(debug, "attaching to next request", *client.codec_client_);

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -232,7 +232,7 @@ void ConnPoolImpl::onUpstreamReady() {
   auto it = delayed_clients_.begin();
   while (it != delayed_clients_.end()) {
     ActiveClient& client = **it;
-    it++;  // Move forward before moveBetweenLists which would invalidate 'it'.
+    it++; // Move forward before moveBetweenLists which would invalidate 'it'.
     client.delayed_--;
     if (client.delayed_ == 0) {
       ENVOY_CONN_LOG(debug, "moving from delay to ready", *client.codec_client_);

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -101,6 +101,7 @@ protected:
     Event::TimerPtr connect_timer_;
     Stats::TimespanPtr conn_length_;
     uint64_t remaining_requests_;
+    bool delayed_{false};
   };
 
   typedef std::unique_ptr<ActiveClient> ActiveClientPtr;
@@ -117,6 +118,7 @@ protected:
 
   Stats::TimespanPtr conn_connect_ms_;
   Event::Dispatcher& dispatcher_;
+  std::list<ActiveClientPtr> delayed_clients_;
   std::list<ActiveClientPtr> ready_clients_;
   std::list<ActiveClientPtr> busy_clients_;
   std::list<DrainedCb> drained_callbacks_;

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -101,7 +101,7 @@ protected:
     Event::TimerPtr connect_timer_;
     Stats::TimespanPtr conn_length_;
     uint64_t remaining_requests_;
-    bool delayed_{false};
+    int delayed_{0};
   };
 
   typedef std::unique_ptr<ActiveClient> ActiveClientPtr;


### PR DESCRIPTION
Signed-off-by: John Plevyak <jplevyak@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: Delay connection reuse until we have done a poll cycle to detect closed connections.
*Risk Level*: low
*Testing*: hand
*Docs Changes*: N/A
*Release Notes*: N/A
[Optional Fixes #Issue] #13848
[Optional *Deprecated*:]
