### PR TITLE
cherry-pick into 1.2:  lua: prevent LuaJIT from panicking. (#6994)

### DIFF
--- a/bazel/foreign_cc/luajit.patch
+++ b/bazel/foreign_cc/luajit.patch
@@ -65,8 +65,8 @@ index 0000000..9c71271
 +
 +    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.6"
 +    os.environ["DEFAULT_CC"] = os.environ.get("CC", "")
-+    os.environ["TARGET_CFLAGS"] = os.environ.get("CFLAGS", "")
-+    os.environ["TARGET_LDFLAGS"] = os.environ.get("CFLAGS", "")
++    os.environ["TARGET_CFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
++    os.environ["TARGET_LDFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
 +    os.environ["CFLAGS"] = ""
 +    # LuaJIT compile process build a tool `buildvm` and use it, building `buildvm` with ASAN
 +    # will cause LSAN detect its leak and fail the build, set exitcode to 0 to make LSAN doesn't


### PR DESCRIPTION
Migration from the build recipes to foreign_cc rules resulted
in dependencies being built with different compiler flags.

Among other things, those compiler flags were added:

    -ffunction-sections -fdata-sections

use of which leads to LuaJIT panicking:

    PANIC: unprotected error in call to Lua API

and Envoy subsequently crashing.

Broken in #6168.

Fixes istio/istio#13722.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*:
*Risk Level*:
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
