### PR TITLE
Update dependency: jwt_verify_lib

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -158,10 +158,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/msgpack/msgpack-c/releases/download/cpp-3.2.0/msgpack-3.2.0.tar.gz"],
     ),
     com_github_google_jwt_verify = dict(
-        sha256 = "8ab9a0b3f8b7eab5f1cd059920e81fdc138cd4ee657c1412af891652929885c5",
-        strip_prefix = "jwt_verify_lib-6356535ae83a3f1820b6b06dae80cd6a0a03e7f2",
-        # 2019-07-01
-        urls = ["https://github.com/google/jwt_verify_lib/archive/6356535ae83a3f1820b6b06dae80cd6a0a03e7f2.tar.gz"],
+        sha256 = "2d57d336239d5fe36a03849ddbea1bff09a1720e1c4a46bbb9743c71732b0d43",
+        strip_prefix = "jwt_verify_lib-0f14d43f20381cfae0469cb2309b2e220c0f0ea3",
+        # 2019-07-08
+        urls = ["https://github.com/google/jwt_verify_lib/archive/0f14d43f20381cfae0469cb2309b2e220c0f0ea3.tar.gz"],
     ),
     com_github_nodejs_http_parser = dict(
         sha256 = "ef26268c54c8084d17654ba2ed5140bffeffd2a040a895ffb22a6cca3f6c613f",


### PR DESCRIPTION
Signed-off-by: Daniel Grimm <dgrimm@redhat.com>

Description: update jwt_verify_lib to support RS384 and RS512 tokens
Risk Level: low
Testing: upstream unit tests
Docs Changes: none
Release Notes: none
Fixes https://github.com/istio/istio/issues/15380

This had previously been merged into the 1.2 release track but is now missing from the 1.3 track due to the switchover to envoy filters. This only targets `release-1.3` because it has been merged upstream (https://github.com/envoyproxy/envoy/pull/8212) and I expect it to be automatically pulled into `master`.