### PR TITLE
[release-1.4] Use sts for call credential when STS_PORT is provided in node metadata #144

### DIFF
--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -249,7 +249,6 @@ Driver::Driver(const envoy::config::trace::v2::OpenCensusConfig& oc_config,
   if (port_iter != node_metadata.fields().end()) {
     sts_port = port_iter->second.string_value();
   }
-  auto google_default_cred = grpc::GoogleDefaultCredentials();
   if (oc_config.stackdriver_exporter_enabled()) {
     ::opencensus::exporters::trace::StackdriverOptions opts;
     opts.project_id = oc_config.stackdriver_project_id();
@@ -257,20 +256,20 @@ Driver::Driver(const envoy::config::trace::v2::OpenCensusConfig& oc_config,
       auto channel =
           grpc::CreateChannel(oc_config.stackdriver_address(), grpc::InsecureChannelCredentials());
       opts.trace_service_stub = ::google::devtools::cloudtrace::v2::TraceService::NewStub(channel);
-    } else if (!sts_port.empty() && google_default_cred) {
+    } else if (!sts_port.empty()) {
       ::grpc::experimental::StsCredentialsOptions sts_options;
-      sts_options.token_exchange_service_uri =
-          "http://localhost:" + sts_port + "/token";
+      sts_options.token_exchange_service_uri = "http://localhost:" + sts_port + "/token";
       sts_options.subject_token_path = "/var/run/secrets/tokens/istio-token";
       sts_options.subject_token_type = "urn:ietf:params:oauth:token-type:jwt";
       sts_options.scope = "https://www.googleapis.com/auth/cloud-platform";
       auto call_creds = grpc::experimental::StsCredentials(sts_options);
-      auto channel = ::grpc::CreateChannel(
-          "cloudtrace.googleapis.com",
-          grpc::CompositeChannelCredentials(google_default_cred,
-                                            call_creds));
-      opts.trace_service_stub =
-          ::google::devtools::cloudtrace::v2::TraceService::NewStub(channel);
+      auto ssl_creds_options = grpc::SslCredentialsOptions();
+      ssl_creds_options.pem_root_certs = "/etc/ssl/certs/ca-certificates.crt";
+      auto channel_creds = grpc::SslCredentials(ssl_creds_options);
+      auto channel =
+          ::grpc::CreateChannel("cloudtrace.googleapis.com",
+                                grpc::CompositeChannelCredentials(channel_creds, call_creds));
+      opts.trace_service_stub = ::google::devtools::cloudtrace::v2::TraceService::NewStub(channel);
     }
     ::opencensus::exporters::trace::StackdriverExporter::Register(std::move(opts));
   }

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -243,6 +243,13 @@ Driver::Driver(const envoy::config::trace::v2::OpenCensusConfig& oc_config,
   if (oc_config.stdout_exporter_enabled()) {
     ::opencensus::exporters::trace::StdoutExporter::Register();
   }
+  auto node_metadata = localinfo.node().metadata();
+  std::string sts_port;
+  auto port_iter = node_metadata.fields().find("STS_PORT");
+  if (port_iter != node_metadata.fields().end()) {
+    sts_port = port_iter->second.string_value();
+  }
+  auto google_default_cred = grpc::GoogleDefaultCredentials();
   if (oc_config.stackdriver_exporter_enabled()) {
     ::opencensus::exporters::trace::StackdriverOptions opts;
     opts.project_id = oc_config.stackdriver_project_id();
@@ -250,6 +257,20 @@ Driver::Driver(const envoy::config::trace::v2::OpenCensusConfig& oc_config,
       auto channel =
           grpc::CreateChannel(oc_config.stackdriver_address(), grpc::InsecureChannelCredentials());
       opts.trace_service_stub = ::google::devtools::cloudtrace::v2::TraceService::NewStub(channel);
+    } else if (!sts_port.empty() && google_default_cred) {
+      ::grpc::experimental::StsCredentialsOptions sts_options;
+      sts_options.token_exchange_service_uri =
+          "http://localhost:" + sts_port + "/token";
+      sts_options.subject_token_path = "/var/run/secrets/tokens/istio-token";
+      sts_options.subject_token_type = "urn:ietf:params:oauth:token-type:jwt";
+      sts_options.scope = "https://www.googleapis.com/auth/cloud-platform";
+      auto call_creds = grpc::experimental::StsCredentials(sts_options);
+      auto channel = ::grpc::CreateChannel(
+          "cloudtrace.googleapis.com",
+          grpc::CompositeChannelCredentials(google_default_cred,
+                                            call_creds));
+      opts.trace_service_stub =
+          ::google::devtools::cloudtrace::v2::TraceService::NewStub(channel);
     }
     ::opencensus::exporters::trace::StackdriverExporter::Register(std::move(opts));
   }


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Corresponding release-1.5 cherry-pick https://github.com/istio/envoy/pull/144

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
