### PR TITLE
Cache and share the base Wasm VM.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -43,10 +43,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://commondatastorage.googleapis.com/chromium-boringssl-docs/fips/boringssl-66005f41fbc3529ffe8d007708756720529da20d.tar.xz"],
     ),
     com_google_absl = dict(
-        sha256 = "190b0c9e65ef0866b44c54b517b5a3e15b67a1001b34547f03f8f4d8553c2851",
-        strip_prefix = "abseil-cpp-63ee2f8877915a3565c29707dba8fe4d7822596a",
-        # 2020-01-08
-        urls = ["https://github.com/abseil/abseil-cpp/archive/63ee2f8877915a3565c29707dba8fe4d7822596a.tar.gz"],
+        sha256 = "19391fb4882601a65cb648d638c11aa301ce5f525ef02da1a9eafd22f72d7c59",
+        strip_prefix = "abseil-cpp-37dd2562ec830d547a1524bb306be313ac3f2556",
+        # 2020-01-29
+        urls = ["https://github.com/abseil/abseil-cpp/archive/37dd2562ec830d547a1524bb306be313ac3f2556.tar.gz"],
     ),
     com_github_apache_thrift = dict(
         sha256 = "7d59ac4fdcb2c58037ebd4a9da5f9a49e3e034bf75b3f26d9fe48ba3d8806e6b",

--- a/source/extensions/access_loggers/wasm/config.cc
+++ b/source/extensions/access_loggers/wasm/config.cc
@@ -45,7 +45,7 @@ WasmAccessLogFactory::createAccessLogInstance(const Protobuf::Message& proto_con
     // NB: the Slot set() call doesn't complete inline, so all arguments must outlive this call.
     tls_slot->set([base_wasm, plugin, configuration](Event::Dispatcher& dispatcher) {
       return std::static_pointer_cast<ThreadLocal::ThreadLocalObject>(
-          Common::Wasm::getOrCreateThreadLocalWasm(*base_wasm, plugin, *configuration, dispatcher));
+          Common::Wasm::getOrCreateThreadLocalWasm(base_wasm, plugin, *configuration, dispatcher));
     });
     access_log->setTlsSlot(std::move(tls_slot));
   };

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -546,18 +546,18 @@ static void createWasmInternal(const VmConfig& vm_config, PluginSharedPtr plugin
         wasm = std::make_shared<WasmHandle>(std::make_shared<Wasm>(
             vm_config.runtime(), vm_config.vm_id(), vm_config.configuration(), vm_key, scope,
             cluster_manager, dispatcher));
+        if (!wasm->wasm()->initialize(code, vm_config.allow_precompiled())) {
+          throw WasmException(fmt::format("Failed to initialize WASM code from {}", source));
+        }
+        if (!context) {
+          wasm->wasm()->start(plugin);
+        } else {
+          wasm->wasm()->startForTesting(std::move(context), plugin);
+        }
         (*base_wasms_)[vm_key] = wasm;
       }
     }
 
-    if (!wasm->wasm()->initialize(code, vm_config.allow_precompiled())) {
-      throw WasmException(fmt::format("Failed to initialize WASM code from {}", source));
-    }
-    if (!context) {
-      wasm->wasm()->start(plugin);
-    } else {
-      wasm->wasm()->startForTesting(std::move(context), plugin);
-    }
     cb(std::move(wasm));
   };
 

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -75,6 +75,7 @@ public:
   Context* vm_context() const { return vm_context_.get(); }
   Stats::StatNameSetSharedPtr stat_name_set() const { return stat_name_set_; }
   Context* getRootContext(absl::string_view root_id) { return root_contexts_[root_id].get(); }
+  Context* getOrCreateRootContext(const PluginSharedPtr& plugin);
   Context* getContext(uint32_t id) {
     auto it = contexts_.find(id);
     if (it != contexts_.end())

--- a/source/extensions/filters/http/wasm/wasm_filter.cc
+++ b/source/extensions/filters/http/wasm/wasm_filter.cc
@@ -27,7 +27,7 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::http::wasm::v3::Was
     // NB: the Slot set() call doesn't complete inline, so all arguments must outlive this call.
     tls_slot_->set([base_wasm, plugin, configuration](Event::Dispatcher& dispatcher) {
       return std::static_pointer_cast<ThreadLocal::ThreadLocalObject>(
-          Common::Wasm::getOrCreateThreadLocalWasm(*base_wasm, plugin, *configuration, dispatcher));
+          Common::Wasm::getOrCreateThreadLocalWasm(base_wasm, plugin, *configuration, dispatcher));
     });
   };
 

--- a/source/extensions/filters/network/wasm/wasm_filter.cc
+++ b/source/extensions/filters/network/wasm/wasm_filter.cc
@@ -22,7 +22,7 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::network::wasm::v3::
     // NB: the Slot set() call doesn't complete inline, so all arguments must outlive this call.
     tls_slot_->set([base_wasm, plugin, configuration](Event::Dispatcher& dispatcher) {
       return std::static_pointer_cast<ThreadLocal::ThreadLocalObject>(
-          Common::Wasm::getOrCreateThreadLocalWasm(*base_wasm, plugin, *configuration, dispatcher));
+          Common::Wasm::getOrCreateThreadLocalWasm(base_wasm, plugin, *configuration, dispatcher));
     });
   };
 

--- a/source/extensions/wasm/config.cc
+++ b/source/extensions/wasm/config.cc
@@ -23,8 +23,7 @@ void WasmFactory::createWasm(const envoy::extensions::wasm::v3::WasmService& con
       config.config().name(), config.config().root_id(), config.config().vm_config().vm_id(),
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, context.localInfo(), nullptr);
 
-  auto callback = [&context, &config, plugin,
-                   cb](std::shared_ptr<Common::Wasm::WasmHandle> base_wasm) {
+  auto callback = [&context, &config, plugin, cb](Common::Wasm::WasmHandleSharedPtr base_wasm) {
     if (config.singleton()) {
       // Return the WASM VM which will be stored as a singleton by the Server.
       auto root_context = base_wasm->wasm()->start(plugin);
@@ -40,7 +39,7 @@ void WasmFactory::createWasm(const envoy::extensions::wasm::v3::WasmService& con
     context.threadLocal().allocateSlot()->set([base_wasm, plugin,
                                                configuration](Event::Dispatcher& dispatcher) {
       return std::static_pointer_cast<ThreadLocal::ThreadLocalObject>(
-          Common::Wasm::getOrCreateThreadLocalWasm(*base_wasm, plugin, *configuration, dispatcher));
+          Common::Wasm::getOrCreateThreadLocalWasm(base_wasm, plugin, *configuration, dispatcher));
     });
     // Do not return this WASM VM since this is per-thread. Returning it would indicate that
     // this is a singleton.

--- a/test/extensions/access_loggers/wasm/config_test.cc
+++ b/test/extensions/access_loggers/wasm/config_test.cc
@@ -62,7 +62,7 @@ TEST_P(WasmAccessLogConfigTest, CreateWasmFromEmpty) {
   AccessLog::InstanceSharedPtr instance;
   EXPECT_THROW_WITH_MESSAGE(
       instance = factory->createAccessLogInstance(*message, std::move(filter), context),
-      Common::Wasm::WasmVmException, "Failed to create WASM VM with unspecified runtime.");
+      Common::Wasm::WasmException, "Failed to load WASM code from ");
 }
 
 TEST_P(WasmAccessLogConfigTest, CreateWasmFromWASM) {

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -52,11 +52,12 @@ TEST_P(WasmCommonTest, Logging) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "logging";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_shared<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   auto wasm_weak = std::weak_ptr<Extensions::Common::Wasm::Wasm>(wasm);
@@ -107,11 +108,12 @@ TEST_P(WasmCommonTest, BadSignature) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -136,11 +138,12 @@ TEST_P(WasmCommonTest, Segv) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "segv";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/common/wasm/test_data/test_cpp.wasm"));
@@ -173,11 +176,12 @@ TEST_P(WasmCommonTest, DivByZero) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "divbyzero";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -211,11 +215,12 @@ TEST_P(WasmCommonTest, EmscriptenVersion) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -244,11 +249,12 @@ TEST_P(WasmCommonTest, IntrinsicGlobals) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "globals";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   std::string code;
@@ -278,11 +284,12 @@ TEST_P(WasmCommonTest, Stats) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "stats";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   std::string code;
@@ -319,11 +326,12 @@ TEST_P(WasmCommonTest, Foreign) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "foreign";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   std::string code;

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -23,7 +23,9 @@ namespace Wasm {
 
 class TestContext : public Extensions::Common::Wasm::Context {
 public:
-  TestContext(Extensions::Common::Wasm::Wasm* wasm) : Extensions::Common::Wasm::Context(wasm) {}
+  TestContext() : Extensions::Common::Wasm::Context() {}
+  explicit TestContext(Extensions::Common::Wasm::Wasm* wasm)
+      : Extensions::Common::Wasm::Context(wasm) {}
   ~TestContext() override {}
   void scriptLog(spdlog::level::level_enum level, absl::string_view message) override {
     std::cerr << std::string(message) << "\n";
@@ -350,6 +352,66 @@ TEST_P(WasmCommonTest, Foreign) {
 
   EXPECT_TRUE(wasm->initialize(code, false));
   wasm->startForTesting(std::move(context), plugin);
+}
+
+TEST_P(WasmCommonTest, VmCache) {
+  Stats::IsolatedStoreImpl stats_store;
+  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  NiceMock<Upstream::MockClusterManager> cluster_manager;
+  NiceMock<Init::MockManager> init_manager;
+  Event::DispatcherPtr dispatcher(api->allocateDispatcher());
+  Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider;
+  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+  auto name = "";
+  auto root_id = "";
+  auto vm_id = "";
+  auto vm_configuration = "vm_cache";
+  auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
+      name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
+      nullptr);
+
+  VmConfig vm_config;
+  vm_config.set_runtime(absl::StrCat("envoy.wasm.runtime.", GetParam()));
+  vm_config.set_configuration(vm_configuration);
+  std::string code;
+  if (GetParam() != "null") {
+    code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
+        absl::StrCat("{{ test_rundir }}/test/extensions/common/wasm/test_data/test_cpp.wasm")));
+  } else {
+    // The name of the Null VM plugin.
+    code = "CommonWasmTestCpp";
+  }
+  EXPECT_FALSE(code.empty());
+  vm_config.mutable_code()->mutable_local()->set_inline_bytes(code);
+  WasmHandleSharedPtr wasm_handle;
+  auto root_context = new Extensions::Common::Wasm::TestContext();
+  EXPECT_CALL(*root_context, scriptLog_(spdlog::level::info, Eq("on_vm_start vm_cache")));
+  EXPECT_CALL(*root_context, scriptLog_(spdlog::level::info, Eq("on_done logging")));
+  EXPECT_CALL(*root_context, scriptLog_(spdlog::level::info, Eq("on_delete logging")));
+  createWasmForTesting(vm_config, plugin, scope, cluster_manager, init_manager, *dispatcher, *api,
+                       std::unique_ptr<Context>(root_context), remote_data_provider,
+                       [&wasm_handle](WasmHandleSharedPtr w) { wasm_handle = w; });
+
+  EXPECT_NE(wasm_handle, nullptr);
+
+  WasmHandleSharedPtr wasm_handle2;
+  auto root_context2 = new Extensions::Common::Wasm::Context();
+  createWasmForTesting(vm_config, plugin, scope, cluster_manager, init_manager, *dispatcher, *api,
+                       std::unique_ptr<Context>(root_context2), remote_data_provider,
+                       [&wasm_handle2](WasmHandleSharedPtr w) { wasm_handle2 = w; });
+  EXPECT_NE(wasm_handle2, nullptr);
+  EXPECT_EQ(wasm_handle, wasm_handle2);
+
+  plugin.reset();
+  auto wasm = wasm_handle->wasm().get();
+  wasm_handle.reset();
+  wasm_handle2.reset();
+
+  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+  wasm->configure(root_context, plugin, "done");
+  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+  dispatcher->clearDeferredDeleteList();
 }
 
 } // namespace Wasm

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -549,7 +549,6 @@ TEST_P(WasmHttpFilterTest, SharedQueue) {
               scriptLog_(spdlog::level::info, Eq(absl::string_view("onQueueReady"))));
   EXPECT_CALL(*root_context_,
               scriptLog_(spdlog::level::debug, Eq(absl::string_view("data data1 Ok"))));
-  EXPECT_CALL(dispatcher_, post(_)).Times(2).WillRepeatedly(Return());
   Http::TestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
   auto token = Common::Wasm::resolveQueueForTest("vm_id", "my_shared_queue");

--- a/test/extensions/wasm/config_test.cc
+++ b/test/extensions/wasm/config_test.cc
@@ -58,7 +58,6 @@ TEST_P(WasmFactoryTest, CreateWasmFromWASM) {
   EXPECT_CALL(init_watcher, ready());
   init_manager.initialize(init_watcher);
   EXPECT_NE(wasmptr, nullptr);
-  EXPECT_CALL(dispatcher, post(_));
   wasmptr.reset();
 }
 
@@ -83,7 +82,6 @@ TEST_P(WasmFactoryTest, CreateWasmFromWASMPerThread) {
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
   Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
                                                         tls, *api, scope, local_info);
-  EXPECT_CALL(dispatcher, post(_));
   factory->createWasm(config, context,
                       [](Server::WasmSharedPtr wasm) { EXPECT_EQ(wasm, nullptr); });
   EXPECT_CALL(init_watcher, ready());
@@ -112,7 +110,6 @@ TEST_P(WasmFactoryTest, MissingImport) {
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
   Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
                                                         tls, *api, scope, local_info);
-  EXPECT_CALL(dispatcher, post(_));
   EXPECT_THROW_WITH_REGEX(factory->createWasm(config, context, [](Server::WasmSharedPtr) {});
                           , Extensions::Common::Wasm::WasmVmException,
                           "Failed to load WASM module due to a missing import: env.missing");

--- a/test/extensions/wasm/wasm_speed_test.cc
+++ b/test/extensions/wasm/wasm_speed_test.cc
@@ -54,12 +54,13 @@ static void BM_WasmSimpleCallSpeedTest(benchmark::State& state, std::string test
   auto root_id = "some_long_root_id";
   auto vm_id = "";
   auto vm_configuration = test;
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", vm), vm_id, vm_configuration, scope, cluster_manager,
-      *dispatcher);
+      absl::StrCat("envoy.wasm.runtime.", vm), vm_id, vm_configuration, vm_key, scope,
+      cluster_manager, *dispatcher);
   std::string code;
   if (vm == "null") {
     code = "WasmSpeedCpp";

--- a/test/extensions/wasm/wasm_test.cc
+++ b/test/extensions/wasm/wasm_test.cc
@@ -64,12 +64,13 @@ TEST_P(WasmTestMatrix, Logging) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_shared<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", std::get<0>(GetParam())), vm_id, vm_configuration, scope,
-      cluster_manager, *dispatcher);
+      absl::StrCat("envoy.wasm.runtime.", std::get<0>(GetParam())), vm_id, vm_configuration, vm_key,
+      scope, cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   auto wasm_weak = std::weak_ptr<Extensions::Common::Wasm::Wasm>(wasm);
   auto wasm_handler = std::make_unique<Extensions::Common::Wasm::WasmHandle>(std::move(wasm));
@@ -111,11 +112,12 @@ TEST_P(WasmTest, BadSignature) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -137,11 +139,12 @@ TEST_P(WasmTest, Segv) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/wasm/test_data/segv_cpp.wasm"));
@@ -174,11 +177,12 @@ TEST_P(WasmTest, DivByZero) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -212,11 +216,12 @@ TEST_P(WasmTest, EmscriptenVersion) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -244,11 +249,12 @@ TEST_P(WasmTest, IntrinsicGlobals) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -278,11 +284,12 @@ TEST_P(WasmTest, Asm2Wasm) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -305,11 +312,12 @@ TEST_P(WasmTest, Stats) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -340,11 +348,12 @@ TEST_P(WasmTest, StatsHigherLevel) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -380,11 +389,12 @@ TEST_P(WasmTest, StatsHighLevel) {
   auto root_id = "";
   auto vm_id = "";
   auto vm_configuration = "";
+  auto vm_key = "";
   auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
       name, root_id, vm_id, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
       nullptr);
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, scope,
+      absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key, scope,
       cluster_manager, *dispatcher);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(


### PR DESCRIPTION
Backport envoyproxy/envoy-wasm#387 and related fixes (envoyproxy/envoy-wasm#400
and envoyproxy/envoy-wasm#413).