### PR TITLE
ci: mark //test/integration:protocol_integration_test as flaky.

### DIFF
--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -158,7 +158,8 @@ def envoy_cc_test(
         shard_count = None,
         coverage = True,
         local = False,
-        size = "medium"):
+        size = "medium",
+        flaky = False):
     if coverage:
         coverage_tags = tags + ["coverage_test_lib"]
     else:
@@ -194,6 +195,7 @@ def envoy_cc_test(
         local = local,
         shard_count = shard_count,
         size = size,
+        flaky = flaky,
     )
 
 # Envoy C++ test related libraries (that want gtest, gmock) should be specified

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -350,6 +350,7 @@ envoy_cc_test(
     srcs = [
         "protocol_integration_test.cc",
     ],
+    flaky = True,
     # As this test has many H1/H2/v4/v6 tests it takes a while to run.
     # Shard it enough to bring the run time in line with other integration tests.
     shard_count = 5,


### PR DESCRIPTION
Backport envoyproxy/envoy-wasm#422 and its prerequisite (envoyproxy/envoy#10009).