### PR TITLE
wasm: restore and fix the Wasm Service. (#440)

### DIFF
--- a/include/envoy/server/wasm.h
+++ b/include/envoy/server/wasm.h
@@ -5,6 +5,7 @@
 #include "envoy/common/exception.h"
 #include "envoy/common/pure.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/thread_local/thread_local.h"
 
 #include "common/common/logger.h"
 
@@ -17,7 +18,19 @@ public:
 };
 
 using WasmSharedPtr = std::shared_ptr<Wasm>;
-using CreateWasmCallback = std::function<void(WasmSharedPtr)>;
+
+class WasmService {
+public:
+  WasmService(WasmSharedPtr singleton) : singleton_(std::move(singleton)) {}
+  WasmService(ThreadLocal::SlotPtr tls_slot) : tls_slot_(std::move(tls_slot)) {}
+
+private:
+  WasmSharedPtr singleton_;
+  ThreadLocal::SlotPtr tls_slot_;
+};
+
+using WasmServicePtr = std::unique_ptr<WasmService>;
+using CreateWasmServiceCallback = std::function<void(WasmServicePtr)>;
 
 } // namespace Server
 } // namespace Envoy

--- a/include/envoy/server/wasm_config.h
+++ b/include/envoy/server/wasm_config.h
@@ -70,12 +70,12 @@ public:
    * @param config const ProtoBuf::Message& supplies the config for the resource monitor
    *        implementation.
    * @param context WasmFactoryContext& supplies the resource monitor's context.
-   * @param cb CreateWasmCallback&& supplies the callback to be called after wasm is created.
+   * @param cb CreateWasmServiceCallback&& supplies the callback to be called after wasm is created.
    * @throw EnvoyException if the implementation is unable to produce an instance with
    *        the provided parameters.
    */
   virtual void createWasm(const envoy::extensions::wasm::v3::WasmService& config,
-                          WasmFactoryContext& context, CreateWasmCallback&& cb) PURE;
+                          WasmFactoryContext& context, CreateWasmServiceCallback&& cb) PURE;
 };
 
 } // namespace Configuration

--- a/source/extensions/wasm/config.h
+++ b/source/extensions/wasm/config.h
@@ -15,7 +15,7 @@ public:
   std::string name() override { return "envoy.wasm"; }
   void createWasm(const envoy::extensions::wasm::v3::WasmService& config,
                   Server::Configuration::WasmFactoryContext& context,
-                  Server::CreateWasmCallback&& cb) override;
+                  Server::CreateWasmServiceCallback&& cb) override;
 
 private:
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider_;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -309,7 +309,7 @@ private:
   Upstream::ProdClusterInfoFactory info_factory_;
   Upstream::HdsDelegatePtr hds_delegate_;
   std::unique_ptr<OverloadManagerImpl> overload_manager_;
-  std::vector<std::shared_ptr<Wasm>> wasm_;
+  std::vector<WasmServicePtr> wasm_;
   Envoy::MutexTracer* mutex_tracer_;
   Grpc::ContextImpl grpc_context_;
   Http::ContextImpl http_context_;


### PR DESCRIPTION
This change restores Wasm Service, which was accidentally removed
in a bad merge (#321).

It also fixes a number of issuses:

1. Wasm Services were started before Cluster Manager was initialized,
   which crashed Envoy when Wasm Service tried to dispatch a callout.

2. Wasm Services (per-thread) were not stored and they were getting
   out of scope, so they were immediately destroyed.

3. Wasm Services (singleton) were started twice.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>