### PR TITLE
[Release-1.5] Use ClusterInfo from streaminfo to get clustername too

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -504,6 +504,9 @@ Context::FindValue(absl::string_view name, Protobuf::Arena* arena) const {
       return CelValue::CreateString(&info->upstreamHost()->cluster().name());
     } else if (info && info->routeEntry()) {
       return CelValue::CreateString(&info->routeEntry()->clusterName());
+    } else if (info && info->upstreamClusterInfo().has_value() &&
+               info->upstreamClusterInfo().value()) {
+      return CelValue::CreateString(&info->upstreamClusterInfo().value()->name());
     }
     break;
   case PropertyToken::CLUSTER_METADATA:


### PR DESCRIPTION
Signed-off-by: gargnupur <gargnupur@google.com>

Remove files

Signed-off-by: gargnupur <gargnupur@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
