### PR TITLE
log: connpool and defer delete.

### DIFF
--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -71,6 +71,8 @@ void DispatcherImpl::clearDeferredDeleteList() {
 
   to_delete->clear();
   deferred_deleting_ = false;
+
+  ENVOY_LOG(trace, "deferred deletion complete, {} deleted", num_to_delete);
 }
 
 Network::ConnectionPtr

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -34,6 +34,12 @@ ConnPoolImpl::~ConnPoolImpl() {
     delayed_clients_.front()->codec_client_->close();
   }
 
+  if (!ready_clients_.empty() || !busy_clients_.empty()) {
+    ENVOY_LOG(debug,
+              "{} ready clients and {} busy clients are deferred deleted with connection pool {}",
+              ready_clients_.size(), busy_clients_.size(), static_cast<void*>(this));
+  }
+
   while (!ready_clients_.empty()) {
     ready_clients_.front()->codec_client_->close();
   }


### PR DESCRIPTION
Description:
The goal is to confirm the number of clients in ConnPool deletion.
Expecting 0 clients during defer deleting connpool.

Should be on top of #191 

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Risk Level: LOW, pure log
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
