### PR TITLE
[release-1.6] zipkin: Fix wrongly rendered timestamp value (#10400)

### DIFF
--- a/source/extensions/tracers/zipkin/span_buffer.cc
+++ b/source/extensions/tracers/zipkin/span_buffer.cc
@@ -9,6 +9,7 @@
 #include "extensions/tracers/zipkin/zipkin_json_field_names.h"
 
 #include "absl/strings/str_join.h"
+#include "absl/strings/str_replace.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -61,7 +62,7 @@ SerializerPtr SpanBuffer::makeSerializer(
 
 std::string JsonV1Serializer::serialize(const std::vector<Span>& zipkin_spans) {
   const std::string serialized_elements =
-      absl::StrJoin(zipkin_spans, ",", [](std::string* element, Span zipkin_span) {
+      absl::StrJoin(zipkin_spans, ",", [](std::string* element, const Span& zipkin_span) {
         absl::StrAppend(element, zipkin_span.toJson());
       });
   return absl::StrCat("[", serialized_elements, "]");
@@ -71,20 +72,46 @@ JsonV2Serializer::JsonV2Serializer(const bool shared_span_context)
     : shared_span_context_{shared_span_context} {}
 
 std::string JsonV2Serializer::serialize(const std::vector<Span>& zipkin_spans) {
-  const std::string serialized_elements =
-      absl::StrJoin(zipkin_spans, ",", [this](std::string* out, const Span& zipkin_span) {
+  Util::Replacements replacements;
+  const std::string serialized_elements = absl::StrJoin(
+      zipkin_spans, ",", [this, &replacements](std::string* out, const Span& zipkin_span) {
+        const auto& replacement_values = replacements;
         absl::StrAppend(
-            out, absl::StrJoin(toListOfSpans(zipkin_span), ",",
-                               [](std::string* element, const ProtobufWkt::Struct& span) {
-                                 absl::StrAppend(element, MessageUtil::getJsonStringFromMessage(
-                                                              span, false, true));
-                               }));
+            out, absl::StrJoin(
+                     toListOfSpans(zipkin_span, replacements), ",",
+                     [&replacement_values](std::string* element, const ProtobufWkt::Struct& span) {
+                       const std::string json = MessageUtil::getJsonStringFromMessage(
+                           span, /* pretty_print */ false,
+                           /* always_print_primitive_fields */ true);
+
+                       // The Zipkin API V2 specification mandates to store timestamp value as int64
+                       // https://github.com/openzipkin/zipkin-api/blob/228fabe660f1b5d1e28eac9df41f7d1deed4a1c2/zipkin2-api.yaml#L447-L463
+                       // (often translated as uint64 in some of the official implementations:
+                       // https://github.com/openzipkin/zipkin-go/blob/62dc8b26c05e0e8b88eb7536eff92498e65bbfc3/model/span.go#L114,
+                       // and see the discussion here:
+                       // https://github.com/openzipkin/zipkin-go/pull/161#issuecomment-598558072).
+                       // However, when the timestamp is stored as number value in a protobuf
+                       // struct, it is stored as a double. Because of how protobuf serializes
+                       // doubles, there is a possibility that the value will be rendered as a
+                       // number with scientific notation as reported in:
+                       // https://github.com/envoyproxy/envoy/issues/9341#issuecomment-566912973. To
+                       // deal with that issue, here we do a workaround by storing the timestamp as
+                       // string and keeping track of that with the corresponding integer
+                       // replacements, and do the replacement here so we can meet the Zipkin API V2
+                       // requirements.
+                       //
+                       // TODO(dio): The right fix for this is to introduce additional knob when
+                       // serializing double in protobuf DoubleToBuffer function, and make it
+                       // available to be controlled at caller site.
+                       // https://github.com/envoyproxy/envoy/issues/10411).
+                       absl::StrAppend(element, absl::StrReplaceAll(json, replacement_values));
+                     }));
       });
   return absl::StrCat("[", serialized_elements, "]");
 }
 
 const std::vector<ProtobufWkt::Struct>
-JsonV2Serializer::toListOfSpans(const Span& zipkin_span) const {
+JsonV2Serializer::toListOfSpans(const Span& zipkin_span, Util::Replacements& replacements) const {
   std::vector<ProtobufWkt::Struct> spans;
   spans.reserve(zipkin_span.annotations().size());
   for (const auto& annotation : zipkin_span.annotations()) {
@@ -103,7 +130,14 @@ JsonV2Serializer::toListOfSpans(const Span& zipkin_span) const {
     }
 
     if (annotation.isSetEndpoint()) {
-      (*fields)[SPAN_TIMESTAMP] = ValueUtil::numberValue(annotation.timestamp());
+      // Usually we store number to a ProtobufWkt::Struct object via ValueUtil::numberValue.
+      // However, due to the possibility of rendering that to a number with scientific notation, we
+      // chose to store it as a string and keeping track the corresponding replacement. For example,
+      // we have 1584324295476870 if we stored it as a double value, MessageToJsonString gives
+      // us 1.58432429547687e+15. Instead we store it as the string of 1584324295476870 (when it is
+      // serialized: "1584324295476870"), and replace it post MessageToJsonString serialization with
+      // integer (1584324295476870 without `"`), see: JsonV2Serializer::serialize.
+      (*fields)[SPAN_TIMESTAMP] = Util::uint64Value(annotation.timestamp(), replacements);
       (*fields)[SPAN_LOCAL_ENDPOINT] =
           ValueUtil::structValue(toProtoEndpoint(annotation.endpoint()));
     }
@@ -121,7 +155,9 @@ JsonV2Serializer::toListOfSpans(const Span& zipkin_span) const {
     }
 
     if (zipkin_span.isSetDuration()) {
-      (*fields)[SPAN_DURATION] = ValueUtil::numberValue(zipkin_span.duration());
+      // Since SPAN_DURATION has the same data type with SPAN_TIMESTAMP, we use Util::uint64Value to
+      // store it.
+      (*fields)[SPAN_DURATION] = Util::uint64Value(zipkin_span.duration(), replacements);
     }
 
     const auto& binary_annotations = zipkin_span.binaryAnnotations();

--- a/source/extensions/tracers/zipkin/span_buffer.h
+++ b/source/extensions/tracers/zipkin/span_buffer.h
@@ -123,7 +123,8 @@ public:
   std::string serialize(const std::vector<Span>& pending_spans) override;
 
 private:
-  const std::vector<ProtobufWkt::Struct> toListOfSpans(const Span& zipkin_span) const;
+  const std::vector<ProtobufWkt::Struct> toListOfSpans(const Span& zipkin_span,
+                                                       Util::Replacements& replacements) const;
   const ProtobufWkt::Struct toProtoEndpoint(const Endpoint& zipkin_endpoint) const;
 
   const bool shared_span_context_;

--- a/source/extensions/tracers/zipkin/util.cc
+++ b/source/extensions/tracers/zipkin/util.cc
@@ -7,6 +7,7 @@
 #include "common/common/hex.h"
 #include "common/common/utility.h"
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 
 namespace Envoy {
@@ -20,6 +21,12 @@ uint64_t Util::generateRandom64(TimeSource& time_source) {
                       .count();
   std::mt19937_64 rand_64(seed);
   return rand_64();
+}
+
+ProtobufWkt::Value Util::uint64Value(uint64_t value, Replacements& replacements) {
+  const std::string string_value = std::to_string(value);
+  replacements.push_back({absl::StrCat("\"", string_value, "\""), string_value});
+  return ValueUtil::stringValue(string_value);
 }
 
 } // namespace Zipkin

--- a/source/extensions/tracers/zipkin/util.h
+++ b/source/extensions/tracers/zipkin/util.h
@@ -6,6 +6,7 @@
 #include "envoy/common/time.h"
 
 #include "common/common/byte_order.h"
+#include "common/protobuf/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -43,6 +44,18 @@ public:
     auto bytes = toEndianness<ByteOrder::BigEndian>(value);
     return std::string(reinterpret_cast<const char*>(&bytes), sizeof(Type));
   }
+
+  using Replacements = std::vector<std::pair<const std::string, const std::string>>;
+
+  /**
+   * Returns a wrapped uint64_t value as a string. In addition to that, it also pushes back a
+   * replacement to the given replacements vector.
+   *
+   * @param value unt64_t number that will be represented in string.
+   * @param replacements a container to hold the required replacements when serializing this value.
+   * @return ProtobufWkt::Value wrapped uint64_t as a string.
+   */
+  static ProtobufWkt::Value uint64Value(uint64_t value, Replacements& replacements);
 };
 
 } // namespace Zipkin

--- a/source/extensions/tracers/zipkin/zipkin_core_types.cc
+++ b/source/extensions/tracers/zipkin/zipkin_core_types.cc
@@ -25,7 +25,7 @@ Endpoint& Endpoint::operator=(const Endpoint& ep) {
   return *this;
 }
 
-const ProtobufWkt::Struct Endpoint::toStruct() const {
+const ProtobufWkt::Struct Endpoint::toStruct(Util::Replacements&) const {
   ProtobufWkt::Struct endpoint;
   auto* fields = endpoint.mutable_fields();
   if (!address_) {
@@ -66,14 +66,14 @@ void Annotation::changeEndpointServiceName(const std::string& service_name) {
   }
 }
 
-const ProtobufWkt::Struct Annotation::toStruct() const {
+const ProtobufWkt::Struct Annotation::toStruct(Util::Replacements& replacements) const {
   ProtobufWkt::Struct annotation;
   auto* fields = annotation.mutable_fields();
-  (*fields)[ANNOTATION_TIMESTAMP] = ValueUtil::numberValue(timestamp_);
+  (*fields)[ANNOTATION_TIMESTAMP] = Util::uint64Value(timestamp_, replacements);
   (*fields)[ANNOTATION_VALUE] = ValueUtil::stringValue(value_);
   if (endpoint_.has_value()) {
     (*fields)[ANNOTATION_ENDPOINT] =
-        ValueUtil::structValue(static_cast<Endpoint>(endpoint_.value()).toStruct());
+        ValueUtil::structValue(static_cast<Endpoint>(endpoint_.value()).toStruct(replacements));
   }
   return annotation;
 }
@@ -98,7 +98,7 @@ BinaryAnnotation& BinaryAnnotation::operator=(const BinaryAnnotation& ann) {
   return *this;
 }
 
-const ProtobufWkt::Struct BinaryAnnotation::toStruct() const {
+const ProtobufWkt::Struct BinaryAnnotation::toStruct(Util::Replacements& replacements) const {
   ProtobufWkt::Struct binary_annotation;
   auto* fields = binary_annotation.mutable_fields();
   (*fields)[BINARY_ANNOTATION_KEY] = ValueUtil::stringValue(key_);
@@ -106,7 +106,7 @@ const ProtobufWkt::Struct BinaryAnnotation::toStruct() const {
 
   if (endpoint_) {
     (*fields)[BINARY_ANNOTATION_ENDPOINT] =
-        ValueUtil::structValue(static_cast<Endpoint>(endpoint_.value()).toStruct());
+        ValueUtil::structValue(static_cast<Endpoint>(endpoint_.value()).toStruct(replacements));
   }
 
   return binary_annotation;
@@ -144,7 +144,7 @@ void Span::setServiceName(const std::string& service_name) {
   }
 }
 
-const ProtobufWkt::Struct Span::toStruct() const {
+const ProtobufWkt::Struct Span::toStruct(Util::Replacements& replacements) const {
   ProtobufWkt::Struct span;
   auto* fields = span.mutable_fields();
   (*fields)[SPAN_TRACE_ID] = ValueUtil::stringValue(traceIdAsHexString());
@@ -156,17 +156,22 @@ const ProtobufWkt::Struct Span::toStruct() const {
   }
 
   if (timestamp_.has_value()) {
-    (*fields)[SPAN_TIMESTAMP] = ValueUtil::numberValue(timestamp_.value());
+    // Usually we store number to a ProtobufWkt::Struct object via ValueUtil::numberValue.
+    // However, due to the possibility of rendering that to a number with scientific notation, we
+    // chose to store it as a string and keeping track the corresponding replacement.
+    (*fields)[SPAN_TIMESTAMP] = Util::uint64Value(timestamp_.value(), replacements);
   }
 
   if (duration_.has_value()) {
-    (*fields)[SPAN_DURATION] = ValueUtil::numberValue(duration_.value());
+    // Since SPAN_DURATION has the same data type with SPAN_TIMESTAMP, we use Util::uint64Value to
+    // store it.
+    (*fields)[SPAN_DURATION] = Util::uint64Value(duration_.value(), replacements);
   }
 
   if (!annotations_.empty()) {
     std::vector<ProtobufWkt::Value> annotation_list;
     for (auto& annotation : annotations_) {
-      annotation_list.push_back(ValueUtil::structValue(annotation.toStruct()));
+      annotation_list.push_back(ValueUtil::structValue(annotation.toStruct(replacements)));
     }
     (*fields)[SPAN_ANNOTATIONS] = ValueUtil::listValue(annotation_list);
   }
@@ -174,7 +179,8 @@ const ProtobufWkt::Struct Span::toStruct() const {
   if (!binary_annotations_.empty()) {
     std::vector<ProtobufWkt::Value> binary_annotation_list;
     for (auto& binary_annotation : binary_annotations_) {
-      binary_annotation_list.push_back(ValueUtil::structValue(binary_annotation.toStruct()));
+      binary_annotation_list.push_back(
+          ValueUtil::structValue(binary_annotation.toStruct(replacements)));
     }
     (*fields)[SPAN_BINARY_ANNOTATIONS] = ValueUtil::listValue(binary_annotation_list);
   }

--- a/test/extensions/tracers/zipkin/BUILD
+++ b/test/extensions/tracers/zipkin/BUILD
@@ -41,7 +41,6 @@ envoy_extension_cc_test(
         "//test/mocks/tracing:tracing_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:simulated_time_system_lib",
-        "//test/test_common:test_time_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/trace/v3:pkg_cc_proto",
     ],

--- a/test/extensions/tracers/zipkin/span_buffer_test.cc
+++ b/test/extensions/tracers/zipkin/span_buffer_test.cc
@@ -1,20 +1,33 @@
 #include "envoy/config/trace/v3/trace.pb.h"
 
 #include "common/network/utility.h"
+#include "common/protobuf/utility.h"
 
 #include "extensions/tracers/zipkin/span_buffer.h"
+#include "extensions/tracers/zipkin/util.h"
 
-#include "test/test_common/test_time.h"
+#include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
 
 #include "absl/strings/str_format.h"
 #include "gtest/gtest.h"
+
+using testing::HasSubstr;
 
 namespace Envoy {
 namespace Extensions {
 namespace Tracers {
 namespace Zipkin {
 namespace {
+
+// If this default timestamp is wrapped as double (using ValueUtil::numberValue()) and then it is
+// serialized using Protobuf::util::MessageToJsonString, it renders as: 1.58432429547687e+15.
+constexpr uint64_t DEFAULT_TEST_TIMESTAMP = 1584324295476870;
+constexpr uint64_t DEFAULT_TEST_DURATION = 2584324295476870;
+const Util::Replacements DEFAULT_TEST_REPLACEMENTS = {
+    {"DEFAULT_TEST_TIMESTAMP", std::to_string(DEFAULT_TEST_TIMESTAMP)}};
+const Util::Replacements DEFAULT_TEST_DURATIONS = {
+    {"DEFAULT_TEST_DURATION", std::to_string(DEFAULT_TEST_DURATION)}};
 
 enum class IpType { V4, V6 };
 
@@ -31,7 +44,7 @@ Endpoint createEndpoint(const IpType ip_type) {
 Annotation createAnnotation(const absl::string_view value, const IpType ip_type) {
   Annotation annotation;
   annotation.setValue(value.data());
-  annotation.setTimestamp(1566058071601051);
+  annotation.setTimestamp(DEFAULT_TEST_TIMESTAMP);
   annotation.setEndpoint(createEndpoint(ip_type));
   return annotation;
 }
@@ -44,11 +57,11 @@ BinaryAnnotation createTag() {
 }
 
 Span createSpan(const std::vector<absl::string_view>& annotation_values, const IpType ip_type) {
-  DangerousDeprecatedTestTime test_time;
-  Span span(test_time.timeSystem());
+  Event::SimulatedTimeSystem simulated_time_system;
+  Span span(simulated_time_system);
   span.setId(1);
   span.setTraceId(1);
-  span.setDuration(100);
+  span.setDuration(DEFAULT_TEST_DURATION);
   std::vector<Annotation> annotations;
   annotations.reserve(annotation_values.size());
   for (absl::string_view value : annotation_values) {
@@ -59,15 +72,25 @@ Span createSpan(const std::vector<absl::string_view>& annotation_values, const I
   return span;
 }
 
+// To render a string with DEFAULT_TEST_TIMESTAMP and DEFAULT_TEST_DURATION placeholder with
+// DEFAULT_TEST_TIMESTAMP and DEFAULT_TEST_DURATION values.
+std::string withDefaultTimestampAndDuration(const std::string& expected) {
+  const auto with_default_timestamp = absl::StrReplaceAll(expected, DEFAULT_TEST_REPLACEMENTS);
+  return absl::StrReplaceAll(with_default_timestamp, DEFAULT_TEST_DURATIONS);
+}
+
 // To wrap JSON array string in a object for JSON string comparison through JsonStringEq test
-// utility.
+// utility. Every DEFAULT_TEST_TIMESTAMP and DEFAULT_TEST_DURATION strings found in array_string
+// will be replaced by DEFAULT_TEST_REPLACEMENTS and DEFAULT_TEST_DURATIONS respectively. i.e. to
+// replace every DEFAULT_TEST_TIMESTAMP string occurrence with DEFAULT_TEST_TIMESTAMP value (the
+// same with DEFAULT_TEST_DURATION).
 std::string wrapAsObject(absl::string_view array_string) {
-  return absl::StrFormat(R"({"root":%s})", array_string);
+  return withDefaultTimestampAndDuration(absl::StrFormat(R"({"root":%s})", array_string));
 }
 
 void expectSerializedBuffer(SpanBuffer& buffer, const bool delay_allocation,
                             const std::vector<std::string>& expected_list) {
-  DangerousDeprecatedTestTime test_time;
+  Event::SimulatedTimeSystem test_time;
 
   EXPECT_EQ(0ULL, buffer.pendingSpans());
   EXPECT_EQ("[]", buffer.serialize());
@@ -105,56 +128,71 @@ template <typename Type> std::string serializedMessageToJson(const std::string& 
   return json;
 }
 
-TEST(ZipkinSpanBufferTest, ConstructBuffer) {
-  const std::string expected1 = R"([{"traceId":"0000000000000001",)"
-                                R"("name":"",)"
-                                R"("id":"0000000000000001",)"
-                                R"("duration":100,)"
-                                R"("annotations":[{"timestamp":1566058071601051,)"
-                                R"("value":"cs",)"
-                                R"("endpoint":{"ipv4":"1.2.3.4",)"
-                                R"("port":8080,)"
-                                R"("serviceName":"service1"}},)"
-                                R"({"timestamp":1566058071601051,)"
-                                R"("value":"sr",)"
-                                R"("endpoint":{"ipv4":"1.2.3.4",)"
-                                R"("port":8080,)"
-                                R"("serviceName":"service1"}}],)"
-                                R"("binaryAnnotations":[{"key":"component",)"
-                                R"("value":"proxy"}]}])";
+TEST(ZipkinSpanBufferTest, TestSerializeTimestamp) {
+  const std::string default_timestamp_string = std::to_string(DEFAULT_TEST_TIMESTAMP);
 
-  const std::string expected2 = R"([{"traceId":"0000000000000001",)"
-                                R"("name":"",)"
-                                R"("id":"0000000000000001",)"
-                                R"("duration":100,)"
-                                R"("annotations":[{"timestamp":1566058071601051,)"
-                                R"("value":"cs",)"
-                                R"("endpoint":{"ipv4":"1.2.3.4",)"
-                                R"("port":8080,)"
-                                R"("serviceName":"service1"}},)"
-                                R"({"timestamp":1566058071601051,)"
-                                R"("value":"sr",)"
-                                R"("endpoint":{"ipv4":"1.2.3.4",)"
-                                R"("port":8080,)"
-                                R"("serviceName":"service1"}}],)"
-                                R"("binaryAnnotations":[{"key":"component",)"
-                                R"("value":"proxy"}]},)"
-                                R"({"traceId":"0000000000000001",)"
-                                R"("name":"",)"
-                                R"("id":"0000000000000001",)"
-                                R"("duration":100,)"
-                                R"("annotations":[{"timestamp":1566058071601051,)"
-                                R"("value":"cs",)"
-                                R"("endpoint":{"ipv4":"1.2.3.4",)"
-                                R"("port":8080,)"
-                                R"("serviceName":"service1"}},)"
-                                R"({"timestamp":1566058071601051,)"
-                                R"("value":"sr",)"
-                                R"("endpoint":{"ipv4":"1.2.3.4",)"
-                                R"("port":8080,)"
-                                R"("serviceName":"service1"}}],)"
-                                R"("binaryAnnotations":[{"key":"component",)"
-                                R"("value":"proxy"}]}])";
+  ProtobufWkt::Struct object;
+  auto* fields = object.mutable_fields();
+  Util::Replacements replacements;
+  (*fields)["timestamp"] = Util::uint64Value(DEFAULT_TEST_TIMESTAMP, replacements);
+
+  ASSERT_EQ(1, replacements.size());
+  EXPECT_EQ(absl::StrCat("\"", default_timestamp_string, "\""), replacements.at(0).first);
+  EXPECT_EQ(default_timestamp_string, replacements.at(0).second);
+}
+
+TEST(ZipkinSpanBufferTest, ConstructBuffer) {
+  const std::string expected1 =
+      withDefaultTimestampAndDuration(R"([{"traceId":"0000000000000001",)"
+                                      R"("name":"",)"
+                                      R"("id":"0000000000000001",)"
+                                      R"("duration":DEFAULT_TEST_DURATION,)"
+                                      R"("annotations":[{"timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                                      R"("value":"cs",)"
+                                      R"("endpoint":{"ipv4":"1.2.3.4",)"
+                                      R"("port":8080,)"
+                                      R"("serviceName":"service1"}},)"
+                                      R"({"timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                                      R"("value":"sr",)"
+                                      R"("endpoint":{"ipv4":"1.2.3.4",)"
+                                      R"("port":8080,)"
+                                      R"("serviceName":"service1"}}],)"
+                                      R"("binaryAnnotations":[{"key":"component",)"
+                                      R"("value":"proxy"}]}])");
+
+  const std::string expected2 =
+      withDefaultTimestampAndDuration(R"([{"traceId":"0000000000000001",)"
+                                      R"("name":"",)"
+                                      R"("id":"0000000000000001",)"
+                                      R"("duration":DEFAULT_TEST_DURATION,)"
+                                      R"("annotations":[{"timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                                      R"("value":"cs",)"
+                                      R"("endpoint":{"ipv4":"1.2.3.4",)"
+                                      R"("port":8080,)"
+                                      R"("serviceName":"service1"}},)"
+                                      R"({"timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                                      R"("value":"sr",)"
+                                      R"("endpoint":{"ipv4":"1.2.3.4",)"
+                                      R"("port":8080,)"
+                                      R"("serviceName":"service1"}}],)"
+                                      R"("binaryAnnotations":[{"key":"component",)"
+                                      R"("value":"proxy"}]},)"
+                                      R"({"traceId":"0000000000000001",)"
+                                      R"("name":"",)"
+                                      R"("id":"0000000000000001",)"
+                                      R"("duration":DEFAULT_TEST_DURATION,)"
+                                      R"("annotations":[{"timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                                      R"("value":"cs",)"
+                                      R"("endpoint":{"ipv4":"1.2.3.4",)"
+                                      R"("port":8080,)"
+                                      R"("serviceName":"service1"}},)"
+                                      R"({"timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                                      R"("value":"sr",)"
+                                      R"("endpoint":{"ipv4":"1.2.3.4",)"
+                                      R"("port":8080,)"
+                                      R"("serviceName":"service1"}}],)"
+                                      R"("binaryAnnotations":[{"key":"component",)"
+                                      R"("value":"proxy"}]}])");
   const bool shared = true;
   const bool delay_allocation = true;
 
@@ -176,8 +214,8 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                            R"("traceId":"0000000000000001",)"
                            R"("id":"0000000000000001",)"
                            R"("kind":"CLIENT",)"
-                           R"("timestamp":1566058071601051,)"
-                           R"("duration":100,)"
+                           R"("timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                           R"("duration":DEFAULT_TEST_DURATION,)"
                            R"("localEndpoint":{)"
                            R"("serviceName":"service1",)"
                            R"("ipv4":"1.2.3.4",)"
@@ -193,8 +231,8 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                            R"("traceId":"0000000000000001",)"
                            R"("id":"0000000000000001",)"
                            R"("kind":"CLIENT",)"
-                           R"("timestamp":1566058071601051,)"
-                           R"("duration":100,)"
+                           R"("timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                           R"("duration":DEFAULT_TEST_DURATION,)"
                            R"("localEndpoint":{)"
                            R"("serviceName":"service1",)"
                            R"("ipv6":"2001:db8:85a3::8a2e:370:4444",)"
@@ -210,8 +248,8 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                            R"("traceId":"0000000000000001",)"
                            R"("id":"0000000000000001",)"
                            R"("kind":"CLIENT",)"
-                           R"("timestamp":1566058071601051,)"
-                           R"("duration":100,)"
+                           R"("timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                           R"("duration":DEFAULT_TEST_DURATION,)"
                            R"("localEndpoint":{)"
                            R"("serviceName":"service1",)"
                            R"("ipv4":"1.2.3.4",)"
@@ -222,8 +260,8 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                            R"("traceId":"0000000000000001",)"
                            R"("id":"0000000000000001",)"
                            R"("kind":"SERVER",)"
-                           R"("timestamp":1566058071601051,)"
-                           R"("duration":100,)"
+                           R"("timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                           R"("duration":DEFAULT_TEST_DURATION,)"
                            R"("localEndpoint":{)"
                            R"("serviceName":"service1",)"
                            R"("ipv4":"1.2.3.4",)"
@@ -240,8 +278,8 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                            R"("traceId":"0000000000000001",)"
                            R"("id":"0000000000000001",)"
                            R"("kind":"CLIENT",)"
-                           R"("timestamp":1566058071601051,)"
-                           R"("duration":100,)"
+                           R"("timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                           R"("duration":DEFAULT_TEST_DURATION,)"
                            R"("localEndpoint":{)"
                            R"("serviceName":"service1",)"
                            R"("ipv4":"1.2.3.4",)"
@@ -252,8 +290,8 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                            R"("traceId":"0000000000000001",)"
                            R"("id":"0000000000000001",)"
                            R"("kind":"SERVER",)"
-                           R"("timestamp":1566058071601051,)"
-                           R"("duration":100,)"
+                           R"("timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                           R"("duration":DEFAULT_TEST_DURATION,)"
                            R"("localEndpoint":{)"
                            R"("serviceName":"service1",)"
                            R"("ipv4":"1.2.3.4",)"
@@ -265,100 +303,148 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
 
   SpanBuffer buffer4(envoy::config::trace::v3::ZipkinConfig::HTTP_PROTO, shared, 2);
   buffer4.addSpan(createSpan({"cs"}, IpType::V4));
-  EXPECT_EQ("{"
-            R"("spans":[{)"
-            R"("traceId":"AAAAAAAAAAE=",)"
-            R"("id":"AQAAAAAAAAA=",)"
-            R"("kind":"CLIENT",)"
-            R"("timestamp":"1566058071601051",)"
-            R"("duration":"100",)"
-            R"("localEndpoint":{)"
-            R"("serviceName":"service1",)"
-            R"("ipv4":"AQIDBA==",)"
-            R"("port":8080},)"
-            R"("tags":{)"
-            R"("component":"proxy"})"
-            "}]}",
+  EXPECT_EQ(withDefaultTimestampAndDuration("{"
+                                            R"("spans":[{)"
+                                            R"("traceId":"AAAAAAAAAAE=",)"
+                                            R"("id":"AQAAAAAAAAA=",)"
+                                            R"("kind":"CLIENT",)"
+                                            R"("timestamp":"DEFAULT_TEST_TIMESTAMP",)"
+                                            R"("duration":"DEFAULT_TEST_DURATION",)"
+                                            R"("localEndpoint":{)"
+                                            R"("serviceName":"service1",)"
+                                            R"("ipv4":"AQIDBA==",)"
+                                            R"("port":8080},)"
+                                            R"("tags":{)"
+                                            R"("component":"proxy"})"
+                                            "}]}"),
             serializedMessageToJson<zipkin::proto3::ListOfSpans>(buffer4.serialize()));
 
   SpanBuffer buffer4_v6(envoy::config::trace::v3::ZipkinConfig::HTTP_PROTO, shared, 2);
   buffer4_v6.addSpan(createSpan({"cs"}, IpType::V6));
-  EXPECT_EQ("{"
-            R"("spans":[{)"
-            R"("traceId":"AAAAAAAAAAE=",)"
-            R"("id":"AQAAAAAAAAA=",)"
-            R"("kind":"CLIENT",)"
-            R"("timestamp":"1566058071601051",)"
-            R"("duration":"100",)"
-            R"("localEndpoint":{)"
-            R"("serviceName":"service1",)"
-            R"("ipv6":"IAENuIWjAAAAAIouA3BERA==",)"
-            R"("port":7334},)"
-            R"("tags":{)"
-            R"("component":"proxy"})"
-            "}]}",
+  EXPECT_EQ(withDefaultTimestampAndDuration("{"
+                                            R"("spans":[{)"
+                                            R"("traceId":"AAAAAAAAAAE=",)"
+                                            R"("id":"AQAAAAAAAAA=",)"
+                                            R"("kind":"CLIENT",)"
+                                            R"("timestamp":"DEFAULT_TEST_TIMESTAMP",)"
+                                            R"("duration":"DEFAULT_TEST_DURATION",)"
+                                            R"("localEndpoint":{)"
+                                            R"("serviceName":"service1",)"
+                                            R"("ipv6":"IAENuIWjAAAAAIouA3BERA==",)"
+                                            R"("port":7334},)"
+                                            R"("tags":{)"
+                                            R"("component":"proxy"})"
+                                            "}]}"),
             serializedMessageToJson<zipkin::proto3::ListOfSpans>(buffer4_v6.serialize()));
 
   SpanBuffer buffer5(envoy::config::trace::v3::ZipkinConfig::HTTP_PROTO, shared, 2);
   buffer5.addSpan(createSpan({"cs", "sr"}, IpType::V4));
-  EXPECT_EQ("{"
-            R"("spans":[{)"
-            R"("traceId":"AAAAAAAAAAE=",)"
-            R"("id":"AQAAAAAAAAA=",)"
-            R"("kind":"CLIENT",)"
-            R"("timestamp":"1566058071601051",)"
-            R"("duration":"100",)"
-            R"("localEndpoint":{)"
-            R"("serviceName":"service1",)"
-            R"("ipv4":"AQIDBA==",)"
-            R"("port":8080},)"
-            R"("tags":{)"
-            R"("component":"proxy"}},)"
-            R"({)"
-            R"("traceId":"AAAAAAAAAAE=",)"
-            R"("id":"AQAAAAAAAAA=",)"
-            R"("kind":"SERVER",)"
-            R"("timestamp":"1566058071601051",)"
-            R"("duration":"100",)"
-            R"("localEndpoint":{)"
-            R"("serviceName":"service1",)"
-            R"("ipv4":"AQIDBA==",)"
-            R"("port":8080},)"
-            R"("tags":{)"
-            R"("component":"proxy"},)"
-            R"("shared":true)"
-            "}]}",
+  EXPECT_EQ(withDefaultTimestampAndDuration("{"
+                                            R"("spans":[{)"
+                                            R"("traceId":"AAAAAAAAAAE=",)"
+                                            R"("id":"AQAAAAAAAAA=",)"
+                                            R"("kind":"CLIENT",)"
+                                            R"("timestamp":"DEFAULT_TEST_TIMESTAMP",)"
+                                            R"("duration":"DEFAULT_TEST_DURATION",)"
+                                            R"("localEndpoint":{)"
+                                            R"("serviceName":"service1",)"
+                                            R"("ipv4":"AQIDBA==",)"
+                                            R"("port":8080},)"
+                                            R"("tags":{)"
+                                            R"("component":"proxy"}},)"
+                                            R"({)"
+                                            R"("traceId":"AAAAAAAAAAE=",)"
+                                            R"("id":"AQAAAAAAAAA=",)"
+                                            R"("kind":"SERVER",)"
+                                            R"("timestamp":"DEFAULT_TEST_TIMESTAMP",)"
+                                            R"("duration":"DEFAULT_TEST_DURATION",)"
+                                            R"("localEndpoint":{)"
+                                            R"("serviceName":"service1",)"
+                                            R"("ipv4":"AQIDBA==",)"
+                                            R"("port":8080},)"
+                                            R"("tags":{)"
+                                            R"("component":"proxy"},)"
+                                            R"("shared":true)"
+                                            "}]}"),
             serializedMessageToJson<zipkin::proto3::ListOfSpans>(buffer5.serialize()));
 
   SpanBuffer buffer6(envoy::config::trace::v3::ZipkinConfig::HTTP_PROTO, !shared, 2);
   buffer6.addSpan(createSpan({"cs", "sr"}, IpType::V4));
-  EXPECT_EQ("{"
-            R"("spans":[{)"
-            R"("traceId":"AAAAAAAAAAE=",)"
-            R"("id":"AQAAAAAAAAA=",)"
-            R"("kind":"CLIENT",)"
-            R"("timestamp":"1566058071601051",)"
-            R"("duration":"100",)"
-            R"("localEndpoint":{)"
-            R"("serviceName":"service1",)"
-            R"("ipv4":"AQIDBA==",)"
-            R"("port":8080},)"
-            R"("tags":{)"
-            R"("component":"proxy"}},)"
-            R"({)"
-            R"("traceId":"AAAAAAAAAAE=",)"
-            R"("id":"AQAAAAAAAAA=",)"
-            R"("kind":"SERVER",)"
-            R"("timestamp":"1566058071601051",)"
-            R"("duration":"100",)"
-            R"("localEndpoint":{)"
-            R"("serviceName":"service1",)"
-            R"("ipv4":"AQIDBA==",)"
-            R"("port":8080},)"
-            R"("tags":{)"
-            R"("component":"proxy"})"
-            "}]}",
+  EXPECT_EQ(withDefaultTimestampAndDuration("{"
+                                            R"("spans":[{)"
+                                            R"("traceId":"AAAAAAAAAAE=",)"
+                                            R"("id":"AQAAAAAAAAA=",)"
+                                            R"("kind":"CLIENT",)"
+                                            R"("timestamp":"DEFAULT_TEST_TIMESTAMP",)"
+                                            R"("duration":"DEFAULT_TEST_DURATION",)"
+                                            R"("localEndpoint":{)"
+                                            R"("serviceName":"service1",)"
+                                            R"("ipv4":"AQIDBA==",)"
+                                            R"("port":8080},)"
+                                            R"("tags":{)"
+                                            R"("component":"proxy"}},)"
+                                            R"({)"
+                                            R"("traceId":"AAAAAAAAAAE=",)"
+                                            R"("id":"AQAAAAAAAAA=",)"
+                                            R"("kind":"SERVER",)"
+                                            R"("timestamp":"DEFAULT_TEST_TIMESTAMP",)"
+                                            R"("duration":"DEFAULT_TEST_DURATION",)"
+                                            R"("localEndpoint":{)"
+                                            R"("serviceName":"service1",)"
+                                            R"("ipv4":"AQIDBA==",)"
+                                            R"("port":8080},)"
+                                            R"("tags":{)"
+                                            R"("component":"proxy"})"
+                                            "}]}"),
             serializedMessageToJson<zipkin::proto3::ListOfSpans>(buffer6.serialize()));
+}
+
+TEST(ZipkinSpanBufferTest, TestSerializeTimestampInTheFuture) {
+  ProtobufWkt::Struct objectWithScientificNotation;
+  auto* objectWithScientificNotationFields = objectWithScientificNotation.mutable_fields();
+  (*objectWithScientificNotationFields)["timestamp"] = ValueUtil::numberValue(
+      DEFAULT_TEST_TIMESTAMP); // the value of DEFAULT_TEST_TIMESTAMP is 1584324295476870.
+  const auto objectWithScientificNotationJson =
+      MessageUtil::getJsonStringFromMessage(objectWithScientificNotation, false, true);
+  // Since we use ValueUtil::numberValue to set the timestamp, we expect to
+  // see the value is rendered with scientific notation (1.58432429547687e+15).
+  EXPECT_EQ(R"({"timestamp":1.58432429547687e+15})", objectWithScientificNotationJson);
+
+  ProtobufWkt::Struct object;
+  auto* objectFields = object.mutable_fields();
+  Util::Replacements replacements;
+  (*objectFields)["timestamp"] = Util::uint64Value(DEFAULT_TEST_TIMESTAMP, replacements);
+  const auto objectJson = MessageUtil::getJsonStringFromMessage(object, false, true);
+  // We still have "1584324295476870" from MessageUtil::getJsonStringFromMessage here.
+  EXPECT_EQ(R"({"timestamp":"1584324295476870"})", objectJson);
+  // However, then the replacement correctly replaces "1584324295476870" with 1584324295476870
+  // (without quotes).
+  EXPECT_EQ(R"({"timestamp":1584324295476870})", absl::StrReplaceAll(objectJson, replacements));
+
+  SpanBuffer bufferDeprecatedJsonV1(envoy::config::trace::v3::ZipkinConfig::HTTP_JSON, true, 2);
+  bufferDeprecatedJsonV1.addSpan(createSpan({"cs"}, IpType::V4));
+  // We do "HasSubstr" here since we could not compare the serialized JSON of a ProtobufWkt::Struct
+  // object, since the positions of keys are not consistent between calls.
+  EXPECT_THAT(bufferDeprecatedJsonV1.serialize(), HasSubstr(R"("timestamp":1584324295476870)"));
+  EXPECT_THAT(bufferDeprecatedJsonV1.serialize(),
+              Not(HasSubstr(R"("timestamp":1.58432429547687e+15)")));
+  EXPECT_THAT(bufferDeprecatedJsonV1.serialize(),
+              Not(HasSubstr(R"("timestamp":"1584324295476870")")));
+  EXPECT_THAT(bufferDeprecatedJsonV1.serialize(), HasSubstr(R"("duration":2584324295476870)"));
+  EXPECT_THAT(bufferDeprecatedJsonV1.serialize(),
+              Not(HasSubstr(R"("duration":2.584324295476870e+15)")));
+  EXPECT_THAT(bufferDeprecatedJsonV1.serialize(),
+              Not(HasSubstr(R"("duration":"2584324295476870")")));
+
+  SpanBuffer bufferJsonV2(
+      envoy::config::trace::v3::ZipkinConfig::hidden_envoy_deprecated_HTTP_JSON_V1, true, 2);
+  bufferJsonV2.addSpan(createSpan({"cs"}, IpType::V4));
+  EXPECT_THAT(bufferJsonV2.serialize(), HasSubstr(R"("timestamp":1584324295476870)"));
+  EXPECT_THAT(bufferJsonV2.serialize(), Not(HasSubstr(R"("timestamp":1.58432429547687e+15)")));
+  EXPECT_THAT(bufferJsonV2.serialize(), Not(HasSubstr(R"("timestamp":"1584324295476870")")));
+  EXPECT_THAT(bufferJsonV2.serialize(), HasSubstr(R"("duration":2584324295476870)"));
+  EXPECT_THAT(bufferJsonV2.serialize(), Not(HasSubstr(R"("duration":2.584324295476870e+15)")));
+  EXPECT_THAT(bufferJsonV2.serialize(), Not(HasSubstr(R"("duration":"2584324295476870")")));
 }
 
 } // namespace

--- a/test/extensions/tracers/zipkin/zipkin_core_types_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_core_types_test.cc
@@ -5,7 +5,7 @@
 #include "extensions/tracers/zipkin/zipkin_core_constants.h"
 #include "extensions/tracers/zipkin/zipkin_core_types.h"
 
-#include "test/test_common/test_time.h"
+#include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -18,17 +18,19 @@ namespace {
 
 TEST(ZipkinCoreTypesEndpointTest, defaultConstructor) {
   Endpoint ep;
+  Util::Replacements replacements;
 
   EXPECT_EQ("", ep.serviceName());
-  EXPECT_TRUE(TestUtility::protoEqual(
-      TestUtility::jsonToStruct(R"({"ipv4":"","port":0,"serviceName":""})"), ep.toStruct()));
+  EXPECT_TRUE(
+      TestUtility::protoEqual(TestUtility::jsonToStruct(R"({"ipv4":"","port":0,"serviceName":""})"),
+                              ep.toStruct(replacements)));
 
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddress("127.0.0.1");
   ep.setAddress(addr);
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(R"({"ipv4":"127.0.0.1","port":0,"serviceName":""})"),
-      ep.toStruct()));
+      ep.toStruct(replacements)));
 
   addr = Network::Utility::parseInternetAddressAndPort(
       "[2001:0db8:85a3:0000:0000:8a2e:0370:4444]:7334");
@@ -36,7 +38,8 @@ TEST(ZipkinCoreTypesEndpointTest, defaultConstructor) {
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(
           R"({"ipv6":"2001:db8:85a3::8a2e:370:4444","port":7334,"serviceName":""})"),
-      ep.toStruct()));
+      ep.toStruct(replacements)));
+  EXPECT_TRUE(replacements.empty());
 
   ep.setServiceName("my_service");
   EXPECT_EQ("my_service", ep.serviceName());
@@ -44,18 +47,21 @@ TEST(ZipkinCoreTypesEndpointTest, defaultConstructor) {
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(
           R"({"ipv6":"2001:db8:85a3::8a2e:370:4444","port":7334,"serviceName":"my_service"})"),
-      ep.toStruct()));
+      ep.toStruct(replacements)));
+  EXPECT_TRUE(replacements.empty());
 }
 
 TEST(ZipkinCoreTypesEndpointTest, customConstructor) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:3306");
   Endpoint ep(std::string("my_service"), addr);
+  Util::Replacements replacements;
 
   EXPECT_EQ("my_service", ep.serviceName());
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})"),
-      ep.toStruct()));
+      ep.toStruct(replacements)));
+  EXPECT_TRUE(replacements.empty());
 
   addr = Network::Utility::parseInternetAddressAndPort(
       "[2001:0db8:85a3:0000:0000:8a2e:0370:4444]:7334");
@@ -64,47 +70,53 @@ TEST(ZipkinCoreTypesEndpointTest, customConstructor) {
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(
           R"({"ipv6":"2001:db8:85a3::8a2e:370:4444","port":7334,"serviceName":"my_service"})"),
-      ep.toStruct()));
+      ep.toStruct(replacements)));
+  EXPECT_TRUE(replacements.empty());
 }
 
 TEST(ZipkinCoreTypesEndpointTest, copyOperator) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:3306");
   Endpoint ep1(std::string("my_service"), addr);
-  const Endpoint& ep2(ep1);
+  Endpoint& ep2(ep1);
+  Util::Replacements replacements;
 
   EXPECT_EQ("my_service", ep1.serviceName());
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})"),
-      ep1.toStruct()));
+      ep1.toStruct(replacements)));
 
   EXPECT_EQ(ep1.serviceName(), ep2.serviceName());
-  EXPECT_TRUE(TestUtility::protoEqual(ep1.toStruct(), ep2.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(ep1.toStruct(replacements), ep2.toStruct(replacements)));
+  EXPECT_TRUE(replacements.empty());
 }
 
 TEST(ZipkinCoreTypesEndpointTest, assignmentOperator) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:3306");
   Endpoint ep1(std::string("my_service"), addr);
-  const Endpoint& ep2 = ep1;
+  Endpoint& ep2 = ep1;
+  Util::Replacements replacements;
 
   EXPECT_EQ("my_service", ep1.serviceName());
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})"),
-      ep1.toStruct()));
+      ep1.toStruct(replacements)));
 
   EXPECT_EQ(ep1.serviceName(), ep2.serviceName());
-  EXPECT_TRUE(TestUtility::protoEqual(ep1.toStruct(), ep2.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(ep1.toStruct(replacements), ep2.toStruct(replacements)));
+  EXPECT_TRUE(replacements.empty());
 }
 
 TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
   Annotation ann;
+  Util::Replacements replacements;
 
   EXPECT_EQ(0ULL, ann.timestamp());
   EXPECT_EQ("", ann.value());
   EXPECT_FALSE(ann.isSetEndpoint());
 
-  DangerousDeprecatedTestTime test_time;
+  Event::SimulatedTimeSystem test_time;
   uint64_t timestamp = std::chrono::duration_cast<std::chrono::microseconds>(
                            test_time.timeSystem().systemTime().time_since_epoch())
                            .count();
@@ -114,10 +126,13 @@ TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
   ann.setValue(CLIENT_SEND);
   EXPECT_EQ(CLIENT_SEND, ann.value());
 
-  std::string expected_json =
-      R"({"timestamp":)" + std::to_string(timestamp) + R"(,"value":")" + CLIENT_SEND + R"("})";
-  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json), ann.toStruct()));
+  std::string expected_json = R"({"timestamp":")" + std::to_string(timestamp) + R"(")" +
+                              R"(,"value":")" + CLIENT_SEND + R"("})";
+  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json),
+                                      ann.toStruct(replacements)));
+  EXPECT_EQ(1, replacements.size());
 
+  replacements.clear();
   // Test the copy-semantics flavor of setEndpoint
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:3306");
@@ -127,13 +142,18 @@ TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
   EXPECT_EQ("my_service", ann.endpoint().serviceName());
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})"),
-      (const_cast<Endpoint&>(ann.endpoint())).toStruct()));
+      (const_cast<Endpoint&>(ann.endpoint())).toStruct(replacements)));
 
-  expected_json = R"({"timestamp":)" + std::to_string(timestamp) + R"(,"value":")" + CLIENT_SEND +
+  expected_json = R"({"timestamp":")" + std::to_string(timestamp) + R"(")" + R"(,"value":")" +
+                  CLIENT_SEND +
                   R"(","endpoint":{"ipv4":)"
                   R"("127.0.0.1","port":3306,"serviceName":"my_service"}})";
-  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json), ann.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json),
+                                      ann.toStruct(replacements)));
 
+  EXPECT_EQ(1, replacements.size());
+
+  replacements.clear();
   // Test the move-semantics flavor of setEndpoint
   addr = Network::Utility::parseInternetAddressAndPort("192.168.1.1:5555");
   Endpoint ep2(std::string("my_service_2"), addr);
@@ -143,31 +163,41 @@ TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(
           R"({"ipv4":"192.168.1.1","port":5555,"serviceName":"my_service_2"})"),
-      (const_cast<Endpoint&>(ann.endpoint())).toStruct()));
+      (const_cast<Endpoint&>(ann.endpoint())).toStruct(replacements)));
+  EXPECT_TRUE(replacements.empty());
 
-  expected_json = R"({"timestamp":)" + std::to_string(timestamp) + R"(,"value":")" + CLIENT_SEND +
+  replacements.clear();
+  expected_json = R"({"timestamp":")" + std::to_string(timestamp) + R"(")" + R"(,"value":")" +
+                  CLIENT_SEND +
                   R"(","endpoint":{"ipv4":"192.168.1.1",)"
                   R"("port":5555,"serviceName":"my_service_2"}})";
-  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json), ann.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json),
+                                      ann.toStruct(replacements)));
+  EXPECT_EQ(1, replacements.size());
 
+  replacements.clear();
   // Test change endpoint service name.
   ann.changeEndpointServiceName("NEW_SERVICE_NAME");
   EXPECT_EQ("NEW_SERVICE_NAME", ann.endpoint().serviceName());
-  expected_json = R"({"timestamp":)" + std::to_string(timestamp) + R"(,"value":")" + CLIENT_SEND +
+  expected_json = R"({"timestamp":")" + std::to_string(timestamp) + R"(")" + R"(,"value":")" +
+                  CLIENT_SEND +
                   R"(","endpoint":{"ipv4":"192.168.1.1",)"
                   R"("port":5555,"serviceName":"NEW_SERVICE_NAME"}})";
-  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json), ann.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json),
+                                      ann.toStruct(replacements)));
+  EXPECT_EQ(1, replacements.size());
 }
 
 TEST(ZipkinCoreTypesAnnotationTest, customConstructor) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:3306");
   Endpoint ep(std::string("my_service"), addr);
-  DangerousDeprecatedTestTime test_time;
+  Event::SimulatedTimeSystem test_time;
   uint64_t timestamp = std::chrono::duration_cast<std::chrono::microseconds>(
                            test_time.timeSystem().systemTime().time_since_epoch())
                            .count();
   Annotation ann(timestamp, CLIENT_SEND, ep);
+  Util::Replacements replacements;
 
   EXPECT_EQ(timestamp, ann.timestamp());
   EXPECT_EQ(CLIENT_SEND, ann.value());
@@ -176,30 +206,34 @@ TEST(ZipkinCoreTypesAnnotationTest, customConstructor) {
   EXPECT_EQ("my_service", ann.endpoint().serviceName());
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})"),
-      (const_cast<Endpoint&>(ann.endpoint())).toStruct()));
+      (const_cast<Endpoint&>(ann.endpoint())).toStruct(replacements)));
+  EXPECT_TRUE(replacements.empty());
 
-  std::string expected_json = R"({"timestamp":)" + std::to_string(timestamp) + R"(,"value":")" +
-                              CLIENT_SEND +
+  std::string expected_json = R"({"timestamp":")" + std::to_string(timestamp) + R"(")" +
+                              R"(,"value":")" + CLIENT_SEND +
                               R"(","endpoint":{"ipv4":"127.0.0.1",)"
                               R"("port":3306,"serviceName":"my_service"}})";
-  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json), ann.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json),
+                                      ann.toStruct(replacements)));
+  EXPECT_EQ(1, replacements.size());
 }
 
 TEST(ZipkinCoreTypesAnnotationTest, copyConstructor) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:3306");
   Endpoint ep(std::string("my_service"), addr);
-  DangerousDeprecatedTestTime test_time;
+  Event::SimulatedTimeSystem test_time;
   uint64_t timestamp = std::chrono::duration_cast<std::chrono::microseconds>(
                            test_time.timeSystem().systemTime().time_since_epoch())
                            .count();
   Annotation ann(timestamp, CLIENT_SEND, ep);
-  const Annotation& ann2(ann);
+  Annotation& ann2(ann);
+  Util::Replacements replacements;
 
   EXPECT_EQ(ann.value(), ann2.value());
   EXPECT_EQ(ann.timestamp(), ann2.timestamp());
   EXPECT_EQ(ann.isSetEndpoint(), ann2.isSetEndpoint());
-  EXPECT_TRUE(TestUtility::protoEqual(ann.toStruct(), ann2.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(ann.toStruct(replacements), ann2.toStruct(replacements)));
   EXPECT_EQ(ann.endpoint().serviceName(), ann2.endpoint().serviceName());
 }
 
@@ -207,22 +241,24 @@ TEST(ZipkinCoreTypesAnnotationTest, assignmentOperator) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:3306");
   Endpoint ep(std::string("my_service"), addr);
-  DangerousDeprecatedTestTime test_time;
+  Event::SimulatedTimeSystem test_time;
   uint64_t timestamp = std::chrono::duration_cast<std::chrono::microseconds>(
                            test_time.timeSystem().systemTime().time_since_epoch())
                            .count();
   Annotation ann(timestamp, CLIENT_SEND, ep);
-  const Annotation& ann2 = ann;
+  Annotation& ann2 = ann;
+  Util::Replacements replacements;
 
   EXPECT_EQ(ann.value(), ann2.value());
   EXPECT_EQ(ann.timestamp(), ann2.timestamp());
   EXPECT_EQ(ann.isSetEndpoint(), ann2.isSetEndpoint());
-  EXPECT_TRUE(TestUtility::protoEqual(ann.toStruct(), ann2.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(ann.toStruct(replacements), ann2.toStruct(replacements)));
   EXPECT_EQ(ann.endpoint().serviceName(), ann2.endpoint().serviceName());
 }
 
 TEST(ZipkinCoreTypesBinaryAnnotationTest, defaultConstructor) {
   BinaryAnnotation ann;
+  Util::Replacements replacements;
 
   EXPECT_EQ("", ann.key());
   EXPECT_EQ("", ann.value());
@@ -236,7 +272,8 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, defaultConstructor) {
   EXPECT_EQ("value", ann.value());
 
   std::string expected_json = R"({"key":"key","value":"value"})";
-  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json), ann.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json),
+                                      ann.toStruct(replacements)));
 
   // Test the copy-semantics flavor of setEndpoint
 
@@ -248,14 +285,15 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, defaultConstructor) {
   EXPECT_EQ("my_service", ann.endpoint().serviceName());
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})"),
-      (const_cast<Endpoint&>(ann.endpoint())).toStruct()));
+      (const_cast<Endpoint&>(ann.endpoint())).toStruct(replacements)));
 
   expected_json = "{"
                   R"("key":"key","value":"value",)"
                   R"("endpoint":)"
                   R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})"
                   "}";
-  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json), ann.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json),
+                                      ann.toStruct(replacements)));
 
   // Test the move-semantics flavor of setEndpoint
   addr = Network::Utility::parseInternetAddressAndPort("192.168.1.1:5555");
@@ -266,51 +304,57 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, defaultConstructor) {
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(
           R"({"ipv4":"192.168.1.1","port":5555,"serviceName":"my_service_2"})"),
-      (const_cast<Endpoint&>(ann.endpoint())).toStruct()));
+      (const_cast<Endpoint&>(ann.endpoint())).toStruct(replacements)));
   expected_json = "{"
                   R"("key":"key","value":"value",)"
                   R"("endpoint":)"
                   R"({"ipv4":"192.168.1.1","port":5555,"serviceName":"my_service_2"})"
                   "}";
-  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json), ann.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json),
+                                      ann.toStruct(replacements)));
 }
 
 TEST(ZipkinCoreTypesBinaryAnnotationTest, customConstructor) {
   BinaryAnnotation ann("key", "value");
+  Util::Replacements replacements;
 
   EXPECT_EQ("key", ann.key());
   EXPECT_EQ("value", ann.value());
   EXPECT_FALSE(ann.isSetEndpoint());
   EXPECT_EQ(AnnotationType::STRING, ann.annotationType());
   std::string expected_json = R"({"key":"key","value":"value"})";
-  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json), ann.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(TestUtility::jsonToStruct(expected_json),
+                                      ann.toStruct(replacements)));
 }
 
 TEST(ZipkinCoreTypesBinaryAnnotationTest, copyConstructor) {
   BinaryAnnotation ann("key", "value");
-  const BinaryAnnotation& ann2(ann);
+  BinaryAnnotation& ann2(ann);
+  Util::Replacements replacements;
 
   EXPECT_EQ(ann.value(), ann2.value());
   EXPECT_EQ(ann.key(), ann2.key());
   EXPECT_EQ(ann.isSetEndpoint(), ann2.isSetEndpoint());
-  EXPECT_TRUE(TestUtility::protoEqual(ann.toStruct(), ann2.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(ann.toStruct(replacements), ann2.toStruct(replacements)));
   EXPECT_EQ(ann.annotationType(), ann2.annotationType());
 }
 
 TEST(ZipkinCoreTypesBinaryAnnotationTest, assignmentOperator) {
   BinaryAnnotation ann("key", "value");
-  const BinaryAnnotation& ann2 = ann;
+  BinaryAnnotation& ann2 = ann;
+  Util::Replacements replacements;
 
   EXPECT_EQ(ann.value(), ann2.value());
   EXPECT_EQ(ann.key(), ann2.key());
   EXPECT_EQ(ann.isSetEndpoint(), ann2.isSetEndpoint());
-  EXPECT_TRUE(TestUtility::protoEqual(ann.toStruct(), ann2.toStruct()));
+  EXPECT_TRUE(TestUtility::protoEqual(ann.toStruct(replacements), ann2.toStruct(replacements)));
   EXPECT_EQ(ann.annotationType(), ann2.annotationType());
 }
 
 TEST(ZipkinCoreTypesSpanTest, defaultConstructor) {
-  DangerousDeprecatedTestTime test_time;
+  Event::SimulatedTimeSystem test_time;
   Span span(test_time.timeSystem());
+  Util::Replacements replacements;
 
   EXPECT_EQ(0ULL, span.id());
   EXPECT_EQ(0ULL, span.traceId());
@@ -329,7 +373,7 @@ TEST(ZipkinCoreTypesSpanTest, defaultConstructor) {
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(
           R"({"traceId":"0000000000000000","name":"","id":"0000000000000000"})"),
-      span.toStruct()));
+      span.toStruct(replacements)));
 
   uint64_t id = Util::generateRandom64(test_time.timeSystem());
   std::string id_hex = Hex::uint64ToHex(id);
@@ -410,16 +454,19 @@ TEST(ZipkinCoreTypesSpanTest, defaultConstructor) {
       TestUtility::jsonToStruct(
           R"({"traceId":")" + span.traceIdAsHexString() + R"(","name":"span_name","id":")" +
           span.idAsHexString() + R"(","parentId":")" + span.parentIdAsHexString() +
-          R"(","timestamp":)" + std::to_string(span.timestamp()) +
-          R"(,"duration":3000,)"
+          R"(","timestamp":")" + std::to_string(span.timestamp()) +
+          R"(")"
+          R"(,"duration":"3000",)"
           R"("annotations":[)"
-          R"({"timestamp":)" +
+          R"({"timestamp":")" +
           std::to_string(span.timestamp()) +
+          R"(")"
           R"(,"value":"cs","endpoint":)"
           R"({"ipv4":"192.168.1.2","port":3306,"serviceName":"my_service_name"}}],)"
           R"("binaryAnnotations":[{"key":"lc","value":"my_component_name","endpoint":)"
           R"({"ipv4":"192.168.1.2","port":3306,"serviceName":"my_service_name"}}]})"),
-      span.toStruct()));
+      span.toStruct(replacements)));
+  EXPECT_EQ(3, replacements.size());
 
   // Test the copy-semantics flavor of addAnnotation and addBinaryAnnotation
 
@@ -444,24 +491,29 @@ TEST(ZipkinCoreTypesSpanTest, defaultConstructor) {
   EXPECT_EQ(3ULL, span.annotations().size());
   EXPECT_EQ(3ULL, span.binaryAnnotations().size());
 
+  replacements.clear();
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(
           R"({"traceId":")" + span.traceIdAsHexString() + R"(","name":"span_name","id":")" +
           span.idAsHexString() + R"(","parentId":")" + span.parentIdAsHexString() +
-          R"(","timestamp":)" + std::to_string(span.timestamp()) +
-          R"(,"duration":3000,)"
+          R"(","timestamp":")" + std::to_string(span.timestamp()) +
+          R"(")"
+          R"(,"duration":"3000",)"
           R"("annotations":[)"
-          R"({"timestamp":)" +
+          R"({"timestamp":")" +
           std::to_string(timestamp) +
+          R"(")"
           R"(,"value":"cs","endpoint":)"
           R"({"ipv4":"192.168.1.2","port":3306,"serviceName":"my_service_name"}},)"
-          R"({"timestamp":)" +
+          R"({"timestamp":")" +
           std::to_string(timestamp) +
+          R"(")"
           R"(,"value":"ss",)"
           R"("endpoint":{"ipv4":"192.168.1.2","port":3306,)"
           R"("serviceName":"my_service_name"}},)"
-          R"({"timestamp":)" +
+          R"({"timestamp":")" +
           std::to_string(timestamp) +
+          R"(")"
           R"(,"value":"sr","endpoint":{"ipv4":"192.168.1.2","port":3306,)"
           R"("serviceName":"my_service_name"}}],)"
           R"("binaryAnnotations":[{"key":"lc","value":"my_component_name",)"
@@ -473,35 +525,42 @@ TEST(ZipkinCoreTypesSpanTest, defaultConstructor) {
           R"({"key":"http.return_code","value":"400",)"
           R"("endpoint":{"ipv4":"192.168.1.2","port":3306,)"
           R"("serviceName":"my_service_name"}}]})"),
-      span.toStruct()));
+      span.toStruct(replacements)));
+  EXPECT_EQ(5, replacements.size());
 
   // Test setSourceServiceName and setDestinationServiceName
 
   ann_copy.setValue(CLIENT_RECV);
   span.addAnnotation(ann_copy);
   span.setServiceName("NEW_SERVICE_NAME");
+  replacements.clear();
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(
           R"({"traceId":")" + span.traceIdAsHexString() + R"(","name":"span_name","id":")" +
           span.idAsHexString() + R"(","parentId":")" + span.parentIdAsHexString() +
-          R"(","timestamp":)" + std::to_string(span.timestamp()) +
-          R"(,"duration":3000,)"
+          R"(","timestamp":")" + std::to_string(span.timestamp()) +
+          R"(")"
+          R"(,"duration":"3000",)"
           R"("annotations":[)"
-          R"({"timestamp":)" +
+          R"({"timestamp":")" +
           std::to_string(timestamp) +
+          R"(")"
           R"(,"value":"cs","endpoint":)"
           R"({"ipv4":"192.168.1.2","port":3306,"serviceName":"NEW_SERVICE_NAME"}},)"
-          R"({"timestamp":)" +
+          R"({"timestamp":")" +
           std::to_string(timestamp) +
+          R"(")"
           R"(,"value":"ss",)"
           R"("endpoint":{"ipv4":"192.168.1.2","port":3306,)"
           R"("serviceName":"NEW_SERVICE_NAME"}},)"
-          R"({"timestamp":)" +
+          R"({"timestamp":")" +
           std::to_string(timestamp) +
+          R"(")"
           R"(,"value":"sr","endpoint":{"ipv4":"192.168.1.2","port":3306,)"
           R"("serviceName":"NEW_SERVICE_NAME"}},)"
-          R"({"timestamp":)" +
+          R"({"timestamp":")" +
           std::to_string(timestamp) +
+          R"(")"
           R"(,"value":"cr","endpoint":)"
           R"({"ipv4":"192.168.1.2","port":3306,"serviceName":"NEW_SERVICE_NAME"}}],)"
           R"("binaryAnnotations":[{"key":"lc","value":"my_component_name",)"
@@ -513,12 +572,14 @@ TEST(ZipkinCoreTypesSpanTest, defaultConstructor) {
           R"({"key":"http.return_code","value":"400",)"
           R"("endpoint":{"ipv4":"192.168.1.2","port":3306,)"
           R"("serviceName":"my_service_name"}}]})"),
-      span.toStruct()));
+      span.toStruct(replacements)));
+  EXPECT_EQ(6, replacements.size());
 }
 
 TEST(ZipkinCoreTypesSpanTest, copyConstructor) {
-  DangerousDeprecatedTestTime test_time;
+  Event::SimulatedTimeSystem test_time;
   Span span(test_time.timeSystem());
+  Util::Replacements replacements;
 
   uint64_t id = Util::generateRandom64(test_time.timeSystem());
   std::string id_hex = Hex::uint64ToHex(id);
@@ -554,8 +615,9 @@ TEST(ZipkinCoreTypesSpanTest, copyConstructor) {
 }
 
 TEST(ZipkinCoreTypesSpanTest, assignmentOperator) {
-  DangerousDeprecatedTestTime test_time;
+  Event::SimulatedTimeSystem test_time;
   Span span(test_time.timeSystem());
+  Util::Replacements replacements;
 
   uint64_t id = Util::generateRandom64(test_time.timeSystem());
   std::string id_hex = Hex::uint64ToHex(id);
@@ -591,7 +653,7 @@ TEST(ZipkinCoreTypesSpanTest, assignmentOperator) {
 }
 
 TEST(ZipkinCoreTypesSpanTest, setTag) {
-  DangerousDeprecatedTestTime test_time;
+  Event::SimulatedTimeSystem test_time;
   Span span(test_time.timeSystem());
 
   span.setTag("key1", "value1");


### PR DESCRIPTION
Manual cherry-pick https://github.com/envoyproxy/envoy/commit/01fe4b620f643bea06bdf5cea3443f9b0767fc40

ref issue: https://github.com/istio/istio/issues/22968

This patch fixes the wrongly rendered timestamp value of serialized
zipkin span by introducing replacers. This path is chosen since the way
protobuf struct holds numeric data is by using double as its data type and
when it is serialized (through `MessageToJsonString`; internally by
`snprintf`-ing the value to a string) sometimes lead to a value with
scientific notation involved (e.g. 1584324295476870 will be printed as
1.58432429547687e+15). A better solution probably by going down to fix
protobuf `MessageToJsonString`.

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
