### PR TITLE
test: deflake RetryHostPredicateFilter

### DIFF
--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -459,7 +459,8 @@ TEST_P(DownstreamProtocolIntegrationTest, RetryHostPredicateFilter) {
       1024);
 
   // Note how we're expecting each upstream request to hit the same upstream.
-  auto upstream_idx = waitForNextUpstreamRequest({0, 1});
+  // We waited default timeout serveral times. We cannot use up all the quota on the first upstream.
+  auto upstream_idx = waitForNextUpstreamRequest({0, 1}, TestUtility::DefaultTimeout / 10);
   ASSERT_TRUE(upstream_idx.has_value());
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
 


### PR DESCRIPTION
Description:
When waiting for any of the up streams available, we should not set a large number of duration for each upstream.
With this change, the test pass rate increase from 50% to 100% on my machine. 
Not sure why the upstream envoy survives.

Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
