### PR TITLE
1.4 - Do not call into the VM unless the VM Context has been created.…

### DIFF
--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -413,6 +413,8 @@ public:
   // Connection
   virtual bool isSsl();
 
+  void setInVmContextCreatedForTesting() { in_vm_context_created_ = true; }
+
 protected:
   friend class Wasm;
   friend struct AsyncClientHandler;

--- a/test/extensions/wasm/wasm_test.cc
+++ b/test/extensions/wasm/wasm_test.cc
@@ -184,7 +184,7 @@ TEST_P(WasmTest, DivByZero) {
   auto context = std::make_unique<TestContext>(wasm.get());
   EXPECT_CALL(*context, scriptLog_(spdlog::level::err, Eq("before div by zero")));
   EXPECT_TRUE(wasm->initialize(code, false));
-  wasm->setContext(context.get());
+  context->setInVmContextCreatedForTesting();
 
   if (GetParam() == "v8") {
     EXPECT_THROW_WITH_MESSAGE(
@@ -388,6 +388,7 @@ TEST_P(WasmTest, StatsHighLevel) {
       "{{ test_rundir }}/test/extensions/wasm/test_data/stats_cpp.wasm"));
   EXPECT_FALSE(code.empty());
   auto context = std::make_unique<TestContext>(wasm.get());
+  context->setInVmContextCreatedForTesting();
 
   EXPECT_CALL(*context, scriptLog_(spdlog::level::trace, Eq("get counter = 1")));
   EXPECT_CALL(*context, scriptLog_(spdlog::level::debug, Eq("get counter = 2")));


### PR DESCRIPTION
… (#24)

* Ensure that the in VM Context is created before onDone is called.

Signed-off-by: John Plevyak <jplevyak@gmail.com>

* Update as per offline discussion.

Signed-off-by: John Plevyak <jplevyak@gmail.com>

* Set in_vm_context_created_ in onNetworkNewConnection.

Signed-off-by: John Plevyak <jplevyak@gmail.com>

* Add guards to other network calls.

Signed-off-by: John Plevyak <jplevyak@gmail.com>

* Fix common/wasm tests.

Signed-off-by: John Plevyak <jplevyak@gmail.com>

* Patch tests.

Signed-off-by: John Plevyak <jplevyak@gmail.com>

* Remove unecessary file from cherry-pick.

Signed-off-by: John Plevyak <jplevyak@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
