### PR TITLE
[release-1.7] load stats: fix integration test flake (#12265)

### DIFF
--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -140,9 +140,9 @@ void LoadStatsReporter::onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&& me
 void LoadStatsReporter::onReceiveMessage(
     std::unique_ptr<envoy::service::load_stats::v3::LoadStatsResponse>&& message) {
   ENVOY_LOG(debug, "New load report epoch: {}", message->DebugString());
-  stats_.requests_.inc();
   message_ = std::move(message);
   startLoadReportPeriod();
+  stats_.requests_.inc();
 }
 
 void LoadStatsReporter::startLoadReportPeriod() {

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -160,7 +160,7 @@ The full command might look something like
 ```
 bazel test //test/integration:http2_upstream_integration_test \
 --test_arg=--gtest_filter="IpVersions/Http2UpstreamIntegrationTest.RouterRequestAndResponseWithBodyNoBuffer/IPv6" \
---jobs 60 --local_ram_resources=1000000000 --local_cpu_resources=1000000000 --runs_per_test=1000 --test_arg="-l trace"
+--jobs 60 --local_test_jobs=60 --runs_per_test=1000 --test_arg="-l trace"
 ```
 
 ## Debugging test flakes


### PR DESCRIPTION
Waiting on a load stats response can race with resetting
the counters when initializing a watch. Moving the counter
increment prevents the race.

Fixes https://github.com/envoyproxy/envoy/issues/11784

Signed-off-by: Matt Klein <mklein@lyft.com>
Signed-off-by: Yuchen Dai <silentdai@gmail.com>