### PR TITLE
Update antlr4 dep for cel, to fix crash

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -19,7 +19,7 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     gazelle_dependencies()
     apple_rules_dependencies()
     upb_bazel_version_repository(name = "upb_bazel_version")
-    antlr_dependencies(471)
+    antlr_dependencies(472)
 
     go_repository(
         name = "org_golang_google_grpc",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -405,12 +405,12 @@ cc_library(
     includes = ["runtime/Cpp/runtime/src"],
 )
 """,
-        sha256 = "4d0714f441333a63e50031c9e8e4890c78f3d21e053d46416949803e122a6574",
+        sha256 = "46f5e1af5f4bd28ade55cb632f9a069656b31fc8c2408f9aa045f9b5f5caad64",
         patch_args = ["-p1"],
         # Patches ASAN violation of initialization fiasco
         patches = ["@envoy//bazel:antlr.patch"],
-        strip_prefix = "antlr4-4.7.1",
-        urls = ["https://github.com/antlr/antlr4/archive/4.7.1.tar.gz"],
+        strip_prefix = "antlr4-4.7.2",
+        urls = ["https://github.com/antlr/antlr4/archive/4.7.2.tar.gz"],
     )
 
 def _com_github_nghttp2_nghttp2():


### PR DESCRIPTION
Updates antlr to fix envoyproxy/envoy-wasm#497

At that time only cel-cpp was updated, but not antlr.
We do not have a unit test that produces the crash.
I have verified that crash does happen with 1.7 build and it does not happen with build that includes antlr-4.7.2.