### PR TITLE
Make opencensus Stackdriver exporter respects initial_metadata option…

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -388,10 +388,10 @@ DEPENDENCY_REPOSITORIES = dict(
         use_category = ["other"],
     ),
     io_opencensus_cpp = dict(
-        sha256 = "193ffb4e13bd7886757fd22b61b7f7a400634412ad8e7e1071e73f57bedd7fc6",
-        strip_prefix = "opencensus-cpp-04ed0211931f12b03c1a76b3907248ca4db7bc90",
-        # 2020-03-24
-        urls = ["https://github.com/census-instrumentation/opencensus-cpp/archive/04ed0211931f12b03c1a76b3907248ca4db7bc90.tar.gz"],
+        sha256 = "12ff300fa804f97bd07e2ff071d969e09d5f3d7bbffeac438c725fa52a51a212",
+        strip_prefix = "opencensus-cpp-7877337633466358ed680f9b26967da5b310d7aa",
+        # 2020-06-01
+        urls = ["https://github.com/census-instrumentation/opencensus-cpp/archive/7877337633466358ed680f9b26967da5b310d7aa.tar.gz"],
         use_category = ["observability"],
         cpe = "N/A",
     ),

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -281,7 +281,17 @@ Driver::Driver(const envoy::config::trace::v3::OpenCensusConfig& oc_config,
         stackdriver_service.mutable_google_grpc()->set_target_uri(GoogleStackdriverTraceAddress);
       }
       auto channel = Envoy::Grpc::GoogleGrpcUtils::createChannel(stackdriver_service, api);
+      // TODO(bianpengyuan): add tests for trace_service_stub and initial_metadata options with mock
+      // stubs.
       opts.trace_service_stub = ::google::devtools::cloudtrace::v2::TraceService::NewStub(channel);
+      const auto& initial_metadata = stackdriver_service.initial_metadata();
+      if (!initial_metadata.empty()) {
+        opts.prepare_client_context = [initial_metadata](grpc::ClientContext* ctx) {
+          for (const auto& metadata : initial_metadata) {
+            ctx->AddMetadata(metadata.key(), metadata.value());
+          }
+        };
+      }
 #else
       throw EnvoyException("Opencensus tracer: cannot handle stackdriver google grpc service, "
                            "google grpc is not built in.");

--- a/test/extensions/tracers/opencensus/config_test.cc
+++ b/test/extensions/tracers/opencensus/config_test.cc
@@ -322,6 +322,9 @@ TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracerStackdriverGrpc) {
         google_grpc:
           target_uri: 127.0.0.1:55678
           stat_prefix: test
+        initial_metadata:
+        - key: foo
+          value: bar
   )EOF";
 
   envoy::config::trace::v3::Tracing configuration;


### PR DESCRIPTION
… (#11831)

Currently Opencensus tracer uses grpcService proto to configure its tracing client stub. It uses GoogleGrpcUtil to construct a channel and create client stub with that. However, the channel created there does not take care of initial_metadata from grpcService configure. This change fills in OCprepare_client_context option in export to make it respect initial metadata.

Risk level: Low

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
