### PR TITLE
tracing: Fix spankind = CLIENT bug when sharedSpanContext is

### DIFF
--- a/source/extensions/tracers/zipkin/tracer.cc
+++ b/source/extensions/tracers/zipkin/tracer.cc
@@ -66,6 +66,14 @@ SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span
 
   span_ptr->setName(span_name);
 
+  // Set the span's kind (client or server)
+  if (config.operationName() == Tracing::OperationName::Egress) {
+    annotation.setValue(ZipkinCoreConstants::get().CLIENT_SEND);
+  } else {
+    annotation.setValue(ZipkinCoreConstants::get().SERVER_RECV);
+  }
+
+  // Set the span's id and parent id
   if (config.operationName() == Tracing::OperationName::Egress || !shared_span_context_) {
     // We need to create a new span that is a child of the previous span; no shared context
 
@@ -75,9 +83,6 @@ SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span
 
     // Set the parent id to the id of the previous span
     span_ptr->setParentId(previous_context.id());
-
-    // Set the CS annotation value
-    annotation.setValue(ZipkinCoreConstants::get().CLIENT_SEND);
 
     // Set the timestamp globally for the span
     span_ptr->setTimestamp(timestamp_micro);
@@ -89,9 +94,6 @@ SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span
     if (previous_context.parent_id()) {
       span_ptr->setParentId(previous_context.parent_id());
     }
-
-    // Set the SR annotation value
-    annotation.setValue(ZipkinCoreConstants::get().SERVER_RECV);
   } else {
     return span_ptr; // return an empty span
   }

--- a/test/extensions/tracers/zipkin/tracer_test.cc
+++ b/test/extensions/tracers/zipkin/tracer_test.cc
@@ -395,15 +395,27 @@ TEST_F(ZipkinTracerTest, SharedSpanContext) {
   const SystemTime timestamp = time_system_.systemTime();
 
   NiceMock<Tracing::MockConfig> config;
-  ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
+  ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Egress));
 
   // Create parent span
   SpanPtr parent_span = tracer.startSpan(config, "parent_span", timestamp);
   SpanContext parent_context(*parent_span);
 
+  // An CS annotation must have been added
+  EXPECT_EQ(1ULL, parent_span->annotations().size());
+  Annotation ann = parent_span->annotations()[0];
+  EXPECT_EQ(ZipkinCoreConstants::get().CLIENT_SEND, ann.value());
+
+  ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
+
   SpanPtr child_span = tracer.startSpan(config, "child_span", timestamp, parent_context);
 
   EXPECT_EQ(parent_span->id(), child_span->id());
+
+  // An SR annotation must have been added
+  EXPECT_EQ(1ULL, child_span->annotations().size());
+  ann = child_span->annotations()[0];
+  EXPECT_EQ(ZipkinCoreConstants::get().SERVER_RECV, ann.value());
 }
 
 // This test checks that when configured to NOT use shared span context, a child span
@@ -419,15 +431,27 @@ TEST_F(ZipkinTracerTest, NotSharedSpanContext) {
   const SystemTime timestamp = time_system_.systemTime();
 
   NiceMock<Tracing::MockConfig> config;
-  ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
+  ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Egress));
 
   // Create parent span
   SpanPtr parent_span = tracer.startSpan(config, "parent_span", timestamp);
   SpanContext parent_context(*parent_span);
 
+  // An CS annotation must have been added
+  EXPECT_EQ(1ULL, parent_span->annotations().size());
+  Annotation ann = parent_span->annotations()[0];
+  EXPECT_EQ(ZipkinCoreConstants::get().CLIENT_SEND, ann.value());
+
+  ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
+
   SpanPtr child_span = tracer.startSpan(config, "child_span", timestamp, parent_context);
 
   EXPECT_EQ(parent_span->id(), child_span->parentId());
+
+  // An SR annotation must have been added
+  EXPECT_EQ(1ULL, child_span->annotations().size());
+  ann = child_span->annotations()[0];
+  EXPECT_EQ(ZipkinCoreConstants::get().SERVER_RECV, ann.value());
 }
 
 } // namespace


### PR DESCRIPTION
 false (#13193)

Signed-off-by: Gary Brown <gary@brownuk.com>
Signed-off-by: Dmitri Dolguikh <dolguik@redhat.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
